### PR TITLE
Add null check for object_lock_configuration and cors_rule

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
 - repo: git://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.19.0
+  rev: v1.31.0
   hooks:
     - id: terraform_fmt
     - id: terraform_docs
 - repo: git://github.com/pre-commit/pre-commit-hooks
-  rev: v2.3.0
+  rev: v3.2.0
   hooks:
     - id: check-merge-conflict

--- a/README.md
+++ b/README.md
@@ -59,28 +59,38 @@ module "s3_bucket" {
 * [Cross-Region Replication](https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/tree/master/examples/s3-replication) - S3 bucket with Cross-Region Replication (CRR) enabled
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| acceleration\_status | (Optional) Sets the accelerate configuration of an existing bucket. Can be Enabled or Suspended. | string | `"null"` | no |
-| acl | (Optional) The canned ACL to apply. Defaults to 'private'. | string | `"private"` | no |
-| bucket | (Optional, Forces new resource) The name of the bucket. If omitted, Terraform will assign a random, unique name. | string | `"null"` | no |
-| bucket\_prefix | (Optional, Forces new resource) Creates a unique bucket name beginning with the specified prefix. Conflicts with bucket. | string | `"null"` | no |
-| cors\_rule | Map containing a rule of Cross-Origin Resource Sharing. | any | `{}` | no |
-| create\_bucket | Controls if S3 bucket should be created | bool | `"true"` | no |
-| force\_destroy | (Optional, Default:false ) A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable. | bool | `"false"` | no |
-| lifecycle\_rule | List of maps containing configuration of object lifecycle management. | any | `[]` | no |
-| logging | Map containing access bucket logging configuration. | map(string) | `{}` | no |
-| object\_lock\_configuration | Map containing S3 object locking configuration. | any | `{}` | no |
-| policy | (Optional) A valid bucket policy JSON document. Note that if the policy document is not specific enough (but still valid), Terraform may view the policy as constantly changing in a terraform plan. In this case, please make sure you use the verbose/specific version of the policy. For more information about building AWS IAM policy documents with Terraform, see the AWS IAM Policy Document Guide. | string | `"null"` | no |
-| region | (Optional) If specified, the AWS region this bucket should reside in. Otherwise, the region used by the callee. | string | `"null"` | no |
-| replication\_configuration | Map containing cross-region replication configuration. | any | `{}` | no |
-| request\_payer | (Optional) Specifies who should bear the cost of Amazon S3 data transfer. Can be either BucketOwner or Requester. By default, the owner of the S3 bucket would incur the costs of any data transfer. See Requester Pays Buckets developer guide for more information. | string | `"null"` | no |
-| server\_side\_encryption\_configuration | Map containing server-side encryption configuration. | any | `{}` | no |
-| tags | (Optional) A mapping of tags to assign to the bucket. | map(string) | `{}` | no |
-| versioning | Map containing versioning configuration. | map(string) | `{}` | no |
-| website | Map containing static web-site hosting or redirect configuration. | map(string) | `{}` | no |
+|------|-------------|------|---------|:--------:|
+| acceleration\_status | (Optional) Sets the accelerate configuration of an existing bucket. Can be Enabled or Suspended. | `string` | `null` | no |
+| acl | (Optional) The canned ACL to apply. Defaults to 'private'. | `string` | `"private"` | no |
+| bucket | (Optional, Forces new resource) The name of the bucket. If omitted, Terraform will assign a random, unique name. | `string` | `null` | no |
+| bucket\_prefix | (Optional, Forces new resource) Creates a unique bucket name beginning with the specified prefix. Conflicts with bucket. | `string` | `null` | no |
+| cors\_rule | Map containing a rule of Cross-Origin Resource Sharing. | `any` | `{}` | no |
+| create\_bucket | Controls if S3 bucket should be created | `bool` | `true` | no |
+| force\_destroy | (Optional, Default:false ) A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable. | `bool` | `false` | no |
+| lifecycle\_rule | List of maps containing configuration of object lifecycle management. | `any` | `[]` | no |
+| logging | Map containing access bucket logging configuration. | `map(string)` | `{}` | no |
+| object\_lock\_configuration | Map containing S3 object locking configuration. | `any` | `{}` | no |
+| policy | (Optional) A valid bucket policy JSON document. Note that if the policy document is not specific enough (but still valid), Terraform may view the policy as constantly changing in a terraform plan. In this case, please make sure you use the verbose/specific version of the policy. For more information about building AWS IAM policy documents with Terraform, see the AWS IAM Policy Document Guide. | `string` | `null` | no |
+| region | (Optional) If specified, the AWS region this bucket should reside in. Otherwise, the region used by the callee. | `string` | `null` | no |
+| replication\_configuration | Map containing cross-region replication configuration. | `any` | `{}` | no |
+| request\_payer | (Optional) Specifies who should bear the cost of Amazon S3 data transfer. Can be either BucketOwner or Requester. By default, the owner of the S3 bucket would incur the costs of any data transfer. See Requester Pays Buckets developer guide for more information. | `string` | `null` | no |
+| server\_side\_encryption\_configuration | Map containing server-side encryption configuration. | `any` | `{}` | no |
+| tags | (Optional) A mapping of tags to assign to the bucket. | `map(string)` | `{}` | no |
+| versioning | Map containing versioning configuration. | `map(string)` | `{}` | no |
+| website | Map containing static web-site hosting or redirect configuration. | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -40,7 +40,6 @@ module "s3_bucket" {
         ReplaceKeyPrefixWith : "documents/"
       }
     }])
-
   }
 
   logging = {

--- a/examples/issue-8-conditional-configuration/README.md
+++ b/examples/issue-8-conditional-configuration/README.md
@@ -1,0 +1,31 @@
+# Issue 8 - S3 Bucket
+
+Configuration in this directory creates S3 bucket which demos the ability to conditionally set configuration parameters.
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Note that this example may create resources which cost money. Run `terraform destroy` when you don't need these resources.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| this\_s3\_bucket\_arn | The ARN of the bucket. Will be of format arn:aws:s3:::bucketname. |
+| this\_s3\_bucket\_bucket\_domain\_name | The bucket domain name. Will be of format bucketname.s3.amazonaws.com. |
+| this\_s3\_bucket\_bucket\_regional\_domain\_name | The bucket region-specific domain name. The bucket domain name including the region name, please refer here for format. Note: The AWS CloudFront allows specifying S3 region-specific endpoint when creating S3 origin, it will prevent redirect issues from CloudFront to S3 Origin URL. |
+| this\_s3\_bucket\_hosted\_zone\_id | The Route 53 Hosted Zone ID for this bucket's region. |
+| this\_s3\_bucket\_id | The name of the bucket. |
+| this\_s3\_bucket\_region | The AWS region this bucket resides in. |
+| this\_s3\_bucket\_website\_domain | The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records. |
+| this\_s3\_bucket\_website\_endpoint | The website endpoint, if the bucket is configured with a website. If not, this will be an empty string. |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/issue-8-conditional-configuration/main.tf
+++ b/examples/issue-8-conditional-configuration/main.tf
@@ -1,0 +1,59 @@
+resource "random_pet" "this" {
+  length = 2
+}
+
+module "s3_bucket" {
+  source = "../../"
+
+  bucket        = "s3-bucket-${random_pet.this.id}"
+  acl           = "private"
+  force_destroy = true
+
+  versioning = false ? {
+    enabled = true
+  } : {}
+
+  website = false ? {
+    index_document = "index.html"
+    error_document = "error.html"
+    routing_rules = jsonencode([{
+      Condition : {
+        KeyPrefixEquals : "docs/"
+      },
+      Redirect : {
+        ReplaceKeyPrefixWith : "documents/"
+      }
+    }])
+  } : {}
+
+  logging = false ? {
+    target_bucket = "some-bucket"
+    target_prefix = "log/"
+  } : {}
+
+  cors_rule = false ? {
+    allowed_methods = ["PUT", "POST"]
+    allowed_origins = ["https://modules.tf", "https://terraform-aws-modules.modules.tf"]
+    allowed_headers = ["*"]
+    expose_headers  = ["ETag"]
+    max_age_seconds = 3000
+  } : null
+
+  server_side_encryption_configuration = false ? {
+    rule = {
+      apply_server_side_encryption_by_default = {
+        sse_algorithm = "aws:kms"
+      }
+    }
+  } : {}
+
+  object_lock_configuration = false ? {
+    object_lock_enabled = "Enabled"
+    rule = {
+      default_retention = {
+        mode  = "COMPLIANCE"
+        years = 5
+      }
+    }
+  } : null
+}

--- a/examples/issue-8-conditional-configuration/outputs.tf
+++ b/examples/issue-8-conditional-configuration/outputs.tf
@@ -1,0 +1,39 @@
+output "this_s3_bucket_id" {
+  description = "The name of the bucket."
+  value       = module.s3_bucket.this_s3_bucket_id
+}
+
+output "this_s3_bucket_arn" {
+  description = "The ARN of the bucket. Will be of format arn:aws:s3:::bucketname."
+  value       = module.s3_bucket.this_s3_bucket_arn
+}
+
+output "this_s3_bucket_bucket_domain_name" {
+  description = "The bucket domain name. Will be of format bucketname.s3.amazonaws.com."
+  value       = module.s3_bucket.this_s3_bucket_bucket_domain_name
+}
+
+output "this_s3_bucket_bucket_regional_domain_name" {
+  description = "The bucket region-specific domain name. The bucket domain name including the region name, please refer here for format. Note: The AWS CloudFront allows specifying S3 region-specific endpoint when creating S3 origin, it will prevent redirect issues from CloudFront to S3 Origin URL."
+  value       = module.s3_bucket.this_s3_bucket_bucket_regional_domain_name
+}
+
+output "this_s3_bucket_hosted_zone_id" {
+  description = "The Route 53 Hosted Zone ID for this bucket's region."
+  value       = module.s3_bucket.this_s3_bucket_hosted_zone_id
+}
+
+output "this_s3_bucket_region" {
+  description = "The AWS region this bucket resides in."
+  value       = module.s3_bucket.this_s3_bucket_region
+}
+
+output "this_s3_bucket_website_endpoint" {
+  description = "The website endpoint, if the bucket is configured with a website. If not, this will be an empty string."
+  value       = module.s3_bucket.this_s3_bucket_website_endpoint
+}
+
+output "this_s3_bucket_website_domain" {
+  description = "The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records. "
+  value       = module.s3_bucket.this_s3_bucket_website_domain
+}

--- a/main.tf
+++ b/main.tf
@@ -197,13 +197,13 @@ resource "aws_s3_bucket" "this" {
 
   # Max 1 block - object_lock_configuration
   dynamic "object_lock_configuration" {
-    for_each = var.object_lock_configuration == null ? [] : length(keys(var.object_lock_configuration)) == 0 ? [] : [var.object_lock_configuration]
+    for_each = length(try(keys(var.object_lock_configuration), {})) == 0 ? [] : [var.object_lock_configuration]
 
     content {
       object_lock_enabled = object_lock_configuration.value.object_lock_enabled
 
       dynamic "rule" {
-        for_each = length(keys(lookup(object_lock_configuration.value, "rule", {}))) == 0 ? [] : [lookup(object_lock_configuration.value, "rule", {})]
+        for_each = length(keys(try(lookup(object_lock_configuration.value, "rule", {}), {}))) == 0 ? [] : [lookup(object_lock_configuration.value, "rule", {})]
 
         content {
           default_retention {

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,6 @@ resource "aws_s3_bucket" "this" {
   tags                = var.tags
   force_destroy       = var.force_destroy
   acceleration_status = var.acceleration_status
-  region              = var.region
   request_payer       = var.request_payer
 
   dynamic "website" {

--- a/main.tf
+++ b/main.tf
@@ -23,7 +23,7 @@ resource "aws_s3_bucket" "this" {
   }
 
   dynamic "cors_rule" {
-    for_each = length(keys(var.cors_rule)) == 0 ? [] : [var.cors_rule]
+    for_each = var.cors_rule == null ? [] : length(keys(var.cors_rule)) == 0 ? [] : [var.cors_rule]
 
     content {
       allowed_methods = cors_rule.value.allowed_methods
@@ -197,7 +197,7 @@ resource "aws_s3_bucket" "this" {
 
   # Max 1 block - object_lock_configuration
   dynamic "object_lock_configuration" {
-    for_each = length(keys(var.object_lock_configuration)) == 0 ? [] : [var.object_lock_configuration]
+    for_each = var.object_lock_configuration == null ? [] : length(keys(var.object_lock_configuration)) == 0 ? [] : [var.object_lock_configuration]
 
     content {
       object_lock_enabled = object_lock_configuration.value.object_lock_enabled


### PR DESCRIPTION
This PR adds null checks for `object_lock_configuration` and `cors_rule` because these parameters are not easily overridden with empty values. To that end, with this PR it is possible to assign `null` to those parameters as a fallback in a condition.

This PR also adds a new example that presents a variant of the complete example, where all parameters (that are not of a primitive type) are set conditionally.

Closes #8.