### PR TITLE
Allow to overwrite the provider (region) when creating the bucket.

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ module "s3_bucket" {
 | region | (Optional) If specified, the AWS region this bucket should reside in. Otherwise, the region used by the callee. | string | `"null"` | no |
 | replication\_configuration | Map containing cross-region replication configuration. | any | `{}` | no |
 | request\_payer | (Optional) Specifies who should bear the cost of Amazon S3 data transfer. Can be either BucketOwner or Requester. By default, the owner of the S3 bucket would incur the costs of any data transfer. See Requester Pays Buckets developer guide for more information. | string | `"null"` | no |
+| alternative_provider | (Optional) | Specifies an alternative provider to use other than the default one. Required when you need to create a bucket in a different region. |
 | server\_side\_encryption\_configuration | Map containing server-side encryption configuration. | any | `{}` | no |
 | tags | (Optional) A mapping of tags to assign to the bucket. | map(string) | `{}` | no |
 | versioning | Map containing versioning configuration. | map(string) | `{}` | no |

--- a/main.tf
+++ b/main.tf
@@ -9,6 +9,7 @@ resource "aws_s3_bucket" "this" {
   acceleration_status = var.acceleration_status
   region              = var.region
   request_payer       = var.request_payer
+  provider            = var.alternative_provider
 
   dynamic "website" {
     for_each = length(keys(var.website)) == 0 ? [] : [var.website]

--- a/variables.tf
+++ b/variables.tf
@@ -70,6 +70,12 @@ variable "request_payer" {
   default     = null
 }
 
+variable "alternative_provider" {
+  description = "(Optional) Specifies an alternative provider to use other than the default one. Required when you need to create a bucket in a different region."
+  type        = string
+  default     = null
+}
+
 variable "website" {
   description = "Map containing static web-site hosting or redirect configuration."
   type        = map(string)


### PR DESCRIPTION
# Description

At the moment this module does not support to overwrite the provider. This is required in scenarios where your provider configuration is defined in one region (p.g eu-west-1) and you need to create a bucket on another region (p.g us-east-1).


See https://github.com/terraform-providers/terraform-provider-aws/issues/5999 and https://www.terraform.io/docs/providers/aws/r/s3_bucket.html
