### PR TITLE
Aws s3 bucket public access block

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
 - repo: git://github.com/antonbabenko/pre-commit-terraform
-  rev: v1.21.0
+  rev: v1.27.0
   hooks:
     - id: terraform_fmt
     - id: terraform_docs
 - repo: git://github.com/pre-commit/pre-commit-hooks
-  rev: v2.4.0
+  rev: v2.5.0
   hooks:
     - id: check-merge-conflict

--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ module "s3_bucket" {
 | tags | (Optional) A mapping of tags to assign to the bucket. | map(string) | `{}` | no |
 | versioning | Map containing versioning configuration. | map(string) | `{}` | no |
 | website | Map containing static web-site hosting or redirect configuration. | map(string) | `{}` | no |
+| block_public_acls | (Optional, Default:true) Whether Amazon S3 should block public ACLs for this bucket | bool | `true` | no |
+| block_public_policy | (Optional, Default:true) Whether Amazon S3 should block public bucket policies for this bucket | bool | `true` | no |
+| ignore_public_acls | (Optional, Default:true) Whether Amazon S3 should ignore public ACLs for this bucket | bool | `true` | no |
+| restrict_public_buckets | (Optional, Default:true) Whether Amazon S3 should restrict public bucket policies for this bucket | bool | `true` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -77,34 +77,40 @@ module "s3_bucket" {
 * [Cross-Region Replication](https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/tree/master/examples/s3-replication) - S3 bucket with Cross-Region Replication (CRR) enabled
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| acceleration\_status | (Optional) Sets the accelerate configuration of an existing bucket. Can be Enabled or Suspended. | string | `"null"` | no |
-| acl | (Optional) The canned ACL to apply. Defaults to 'private'. | string | `"private"` | no |
-| attach\_elb\_log\_delivery\_policy | Controls if S3 bucket should have ELB log delivery policy attached | bool | `"false"` | no |
-| attach\_policy | Controls if S3 bucket should have bucket policy attached (set to `true` to use value of `policy` as bucket policy) | bool | `"false"` | no |
-| bucket | (Optional, Forces new resource) The name of the bucket. If omitted, Terraform will assign a random, unique name. | string | `"null"` | no |
-| bucket\_prefix | (Optional, Forces new resource) Creates a unique bucket name beginning with the specified prefix. Conflicts with bucket. | string | `"null"` | no |
-| cors\_rule | Map containing a rule of Cross-Origin Resource Sharing. | any | `{}` | no |
-| create\_bucket | Controls if S3 bucket should be created | bool | `"true"` | no |
-| force\_destroy | (Optional, Default:false ) A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable. | bool | `"false"` | no |
-| lifecycle\_rule | List of maps containing configuration of object lifecycle management. | any | `[]` | no |
-| logging | Map containing access bucket logging configuration. | map(string) | `{}` | no |
-| object\_lock\_configuration | Map containing S3 object locking configuration. | any | `{}` | no |
-| policy | (Optional) A valid bucket policy JSON document. Note that if the policy document is not specific enough (but still valid), Terraform may view the policy as constantly changing in a terraform plan. In this case, please make sure you use the verbose/specific version of the policy. For more information about building AWS IAM policy documents with Terraform, see the AWS IAM Policy Document Guide. | string | `"null"` | no |
-| region | (Optional) If specified, the AWS region this bucket should reside in. Otherwise, the region used by the callee. | string | `"null"` | no |
-| replication\_configuration | Map containing cross-region replication configuration. | any | `{}` | no |
-| request\_payer | (Optional) Specifies who should bear the cost of Amazon S3 data transfer. Can be either BucketOwner or Requester. By default, the owner of the S3 bucket would incur the costs of any data transfer. See Requester Pays Buckets developer guide for more information. | string | `"null"` | no |
-| server\_side\_encryption\_configuration | Map containing server-side encryption configuration. | any | `{}` | no |
-| tags | (Optional) A mapping of tags to assign to the bucket. | map(string) | `{}` | no |
-| versioning | Map containing versioning configuration. | map(string) | `{}` | no |
-| website | Map containing static web-site hosting or redirect configuration. | map(string) | `{}` | no |
-| block_public_acls | (Optional, Default:true) Whether Amazon S3 should block public ACLs for this bucket | bool | `true` | no |
-| block_public_policy | (Optional, Default:true) Whether Amazon S3 should block public bucket policies for this bucket | bool | `true` | no |
-| ignore_public_acls | (Optional, Default:true) Whether Amazon S3 should ignore public ACLs for this bucket | bool | `true` | no |
-| restrict_public_buckets | (Optional, Default:true) Whether Amazon S3 should restrict public bucket policies for this bucket | bool | `true` | no |
+|------|-------------|------|---------|:-----:|
+| acceleration\_status | (Optional) Sets the accelerate configuration of an existing bucket. Can be Enabled or Suspended. | `string` | n/a | yes |
+| acl | (Optional) The canned ACL to apply. Defaults to 'private'. | `string` | `"private"` | no |
+| attach\_elb\_log\_delivery\_policy | Controls if S3 bucket should have ELB log delivery policy attached | `bool` | `false` | no |
+| attach\_policy | Controls if S3 bucket should have bucket policy attached (set to `true` to use value of `policy` as bucket policy) | `bool` | `false` | no |
+| block\_public\_acls | Whether Amazon S3 should block public ACLs for this bucket. | `bool` | `false` | no |
+| block\_public\_policy | Whether Amazon S3 should block public bucket policies for this bucket. | `bool` | `false` | no |
+| bucket | (Optional, Forces new resource) The name of the bucket. If omitted, Terraform will assign a random, unique name. | `string` | n/a | yes |
+| bucket\_prefix | (Optional, Forces new resource) Creates a unique bucket name beginning with the specified prefix. Conflicts with bucket. | `string` | n/a | yes |
+| cors\_rule | Map containing a rule of Cross-Origin Resource Sharing. | `any` | `{}` | no |
+| create\_bucket | Controls if S3 bucket should be created | `bool` | `true` | no |
+| force\_destroy | (Optional, Default:false ) A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable. | `bool` | `false` | no |
+| ignore\_public\_acls | Whether Amazon S3 should ignore public ACLs for this bucket. | `bool` | `false` | no |
+| lifecycle\_rule | List of maps containing configuration of object lifecycle management. | `any` | `[]` | no |
+| logging | Map containing access bucket logging configuration. | `map(string)` | `{}` | no |
+| object\_lock\_configuration | Map containing S3 object locking configuration. | `any` | `{}` | no |
+| policy | (Optional) A valid bucket policy JSON document. Note that if the policy document is not specific enough (but still valid), Terraform may view the policy as constantly changing in a terraform plan. In this case, please make sure you use the verbose/specific version of the policy. For more information about building AWS IAM policy documents with Terraform, see the AWS IAM Policy Document Guide. | `string` | n/a | yes |
+| region | (Optional) If specified, the AWS region this bucket should reside in. Otherwise, the region used by the callee. | `string` | n/a | yes |
+| replication\_configuration | Map containing cross-region replication configuration. | `any` | `{}` | no |
+| request\_payer | (Optional) Specifies who should bear the cost of Amazon S3 data transfer. Can be either BucketOwner or Requester. By default, the owner of the S3 bucket would incur the costs of any data transfer. See Requester Pays Buckets developer guide for more information. | `string` | n/a | yes |
+| restrict\_public\_buckets | Whether Amazon S3 should restrict public bucket policies for this bucket. | `bool` | `false` | no |
+| server\_side\_encryption\_configuration | Map containing server-side encryption configuration. | `any` | `{}` | no |
+| tags | (Optional) A mapping of tags to assign to the bucket. | `map(string)` | `{}` | no |
+| versioning | Map containing versioning configuration. | `map(string)` | `{}` | no |
+| website | Map containing static web-site hosting or redirect configuration. | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -24,6 +24,17 @@ $ terraform apply
 Note that this example may create resources which cost money. Run `terraform destroy` when you don't need these resources.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+| random | n/a |
+
+## Inputs
+
+No input.
+
 ## Outputs
 
 | Name | Description |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -174,4 +174,10 @@ module "s3_bucket" {
       }
     }
   }
+
+  // S3 bucket-level Public Access Block configuration
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
 }

--- a/examples/s3-replication/README.md
+++ b/examples/s3-replication/README.md
@@ -17,6 +17,18 @@ $ terraform apply
 Note that this example may create resources which cost money. Run `terraform destroy` when you don't need these resources.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+| aws.replica | n/a |
+| random | n/a |
+
+## Inputs
+
+No input.
+
 ## Outputs
 
 | Name | Description |

--- a/main.tf
+++ b/main.tf
@@ -251,3 +251,12 @@ data "aws_iam_policy_document" "elb_log_delivery" {
     ]
   }
 }
+
+resource "aws_s3_bucket_public_access_block" "this" {
+  bucket = "${aws_s3_bucket.this[0].id}"
+
+  block_public_acls       = var.block_public_acls
+  block_public_policy     = var.block_public_policy
+  ignore_public_acls      = var.ignore_public_acls
+  restrict_public_buckets = var.restrict_public_buckets
+}

--- a/main.tf
+++ b/main.tf
@@ -253,7 +253,11 @@ data "aws_iam_policy_document" "elb_log_delivery" {
 }
 
 resource "aws_s3_bucket_public_access_block" "this" {
-  bucket = "${aws_s3_bucket.this[0].id}"
+  count = var.create_bucket ? 1 : 0
+
+  // Chain resources (s3_bucket -> s3_bucket_policy -> s3_bucket_public_access_block)
+  // to prevent "A conflicting conditional operation is currently in progress against this resource."
+  bucket = (var.attach_elb_log_delivery_policy || var.attach_policy) ? aws_s3_bucket_policy.this[0].id : aws_s3_bucket.this[0].id
 
   block_public_acls       = var.block_public_acls
   block_public_policy     = var.block_public_policy

--- a/variables.tf
+++ b/variables.tf
@@ -117,3 +117,27 @@ variable "object_lock_configuration" {
   type        = any
   default     = {}
 }
+
+variable "block_public_acls" {
+  description = "Controls if S3 bucket should be created"
+  type        = bool
+  default     = true
+}
+
+variable "block_public_policy" {
+  description = "Controls if S3 bucket should be created"
+  type        = bool
+  default     = true
+}
+
+variable "ignore_public_acls" {
+  description = "Controls if S3 bucket should be created"
+  type        = bool
+  default     = true
+}
+
+variable "restrict_public_buckets" {
+  description = "Controls if S3 bucket should be created"
+  type        = bool
+  default     = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -119,25 +119,25 @@ variable "object_lock_configuration" {
 }
 
 variable "block_public_acls" {
-  description = "(Optional, Default:true) Whether Amazon S3 should block public ACLs for this bucket"
+  description = "Whether Amazon S3 should block public ACLs for this bucket."
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "block_public_policy" {
-  description = "(Optional, Default:true) Whether Amazon S3 should block public bucket policies for this bucket"
+  description = "Whether Amazon S3 should block public bucket policies for this bucket."
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "ignore_public_acls" {
-  description = "(Optional, Default:true) Whether Amazon S3 should ignore public ACLs for this bucket"
+  description = "Whether Amazon S3 should ignore public ACLs for this bucket."
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "restrict_public_buckets" {
-  description = "(Optional, Default:true) Whether Amazon S3 should restrict public bucket policies for this bucket"
+  description = "Whether Amazon S3 should restrict public bucket policies for this bucket."
   type        = bool
-  default     = true
+  default     = false
 }

--- a/variables.tf
+++ b/variables.tf
@@ -119,25 +119,25 @@ variable "object_lock_configuration" {
 }
 
 variable "block_public_acls" {
-  description = "Controls if S3 bucket should be created"
+  description = "(Optional, Default:true) Whether Amazon S3 should block public ACLs for this bucket"
   type        = bool
   default     = true
 }
 
 variable "block_public_policy" {
-  description = "Controls if S3 bucket should be created"
+  description = "(Optional, Default:true) Whether Amazon S3 should block public bucket policies for this bucket"
   type        = bool
   default     = true
 }
 
 variable "ignore_public_acls" {
-  description = "Controls if S3 bucket should be created"
+  description = "(Optional, Default:true) Whether Amazon S3 should ignore public ACLs for this bucket"
   type        = bool
   default     = true
 }
 
 variable "restrict_public_buckets" {
-  description = "Controls if S3 bucket should be created"
+  description = "(Optional, Default:true) Whether Amazon S3 should restrict public bucket policies for this bucket"
   type        = bool
   default     = true
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_version = "~> 0.12.6"
+
+  required_providers {
+    aws = "~> 2.35"
+  }
+}


### PR DESCRIPTION
Prior to this change, the module didn't have support for blocking public access check [here](https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html) and [here](https://www.terraform.io/docs/providers/aws/r/s3_bucket_public_access_block.html).

All the blocking defaults to `true` and can be adjusted with variables. Hopefully this PR resolves issues #7 and #17 .

New version can be tested with following example:
```
module "s3_bucket" {
  source = "github.com/serhatcetinkaya/terraform-aws-s3-bucket?ref=aws_s3_bucket_public_access_block"

  bucket = "my-s3-bucket-test-blocking-public-access"
  acl    = "private"

  versioning = {
    enabled = true
  }

}
```
