### PR TITLE
feat: Added attach_public_policy as conditional switch

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.30.0
+    rev: v1.31.0
     hooks:
       - id: terraform_fmt
       - id: terraform_docs

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ module "s3_bucket" {
 | acl | (Optional) The canned ACL to apply. Defaults to 'private'. | `string` | `"private"` | no |
 | attach\_elb\_log\_delivery\_policy | Controls if S3 bucket should have ELB log delivery policy attached | `bool` | `false` | no |
 | attach\_policy | Controls if S3 bucket should have bucket policy attached (set to `true` to use value of `policy` as bucket policy) | `bool` | `false` | no |
+| attach\_public\_policy | Controls if a user defined public bucket policy will be attached (set to `false` to allow upstream to apply defaults to the bucket) | `bool` | `true` | no |
 | block\_public\_acls | Whether Amazon S3 should block public ACLs for this bucket. | `bool` | `false` | no |
 | block\_public\_policy | Whether Amazon S3 should block public bucket policies for this bucket. | `bool` | `false` | no |
 | bucket | (Optional, Forces new resource) The name of the bucket. If omitted, Terraform will assign a random, unique name. | `string` | `null` | no |

--- a/examples/notification/README.md
+++ b/examples/notification/README.md
@@ -24,6 +24,7 @@ No requirements.
 | Name | Version |
 |------|---------|
 | aws | n/a |
+| null | n/a |
 | random | n/a |
 
 ## Inputs

--- a/examples/notification/main.tf
+++ b/examples/notification/main.tf
@@ -85,17 +85,17 @@ module "all_notifications" {
 
   lambda_notifications = {
     lambda1 = {
-      function_arn = module.lambda_function1.this_lambda_function_arn
+      function_arn  = module.lambda_function1.this_lambda_function_arn
       function_name = module.lambda_function1.this_lambda_function_name
-      events              = ["s3:ObjectCreated:Put"]
-      filter_prefix       = "prefix/"
-      filter_suffix       = ".json"
+      events        = ["s3:ObjectCreated:Put"]
+      filter_prefix = "prefix/"
+      filter_suffix = ".json"
     }
 
     lambda2 = {
-      function_arn = module.lambda_function2.this_lambda_function_arn
+      function_arn  = module.lambda_function2.this_lambda_function_arn
       function_name = module.lambda_function2.this_lambda_function_name
-      events              = ["s3:ObjectCreated:Post"]
+      events        = ["s3:ObjectCreated:Post"]
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -253,7 +253,7 @@ data "aws_iam_policy_document" "elb_log_delivery" {
 }
 
 resource "aws_s3_bucket_public_access_block" "this" {
-  count = var.create_bucket ? 1 : 0
+  count = var.create_bucket && var.attach_public_policy ? 1 : 0
 
   // Chain resources (s3_bucket -> s3_bucket_policy -> s3_bucket_public_access_block)
   // to prevent "A conflicting conditional operation is currently in progress against this resource."

--- a/modules/notification/main.tf
+++ b/modules/notification/main.tf
@@ -61,7 +61,7 @@ resource "aws_lambda_permission" "allow" {
   statement_id_prefix = "AllowLambdaS3BucketNotification-"
   action              = "lambda:InvokeFunction"
   function_name       = each.value.function_name
-  qualifier = lookup(each.value, "qualifier", null)
+  qualifier           = lookup(each.value, "qualifier", null)
   principal           = "s3.amazonaws.com"
   source_arn          = local.bucket_arn
 }

--- a/variables.tf
+++ b/variables.tf
@@ -16,6 +16,12 @@ variable "attach_policy" {
   default     = false
 }
 
+variable "attach_public_policy" {
+  description = "Controls if a user defined public bucket policy will be attached (set to `false` to allow upstream to apply defaults to the bucket)"
+  type        = bool
+  default     = true
+}
+
 variable "bucket" {
   description = "(Optional, Forces new resource) The name of the bucket. If omitted, Terraform will assign a random, unique name."
   type        = string


### PR DESCRIPTION
## Description
Add a bool which controls the creation of resource "aws_s3_bucket_public_access_block"

## Motivation and Context
We have an environment where S3 buckets are being created under a role without `PutBucketPolicy`.

## Breaking Changes
No, by default the behavior will remain the same.

## How Has This Been Tested?
Tested against a role without `PutBucketPolicy`.
