### PR TITLE
fix: Using required arguments instead of lookup in replication_configuration

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -118,13 +118,13 @@ resource "aws_s3_bucket" "this" {
           id       = lookup(rules.value, "id", null)
           priority = lookup(rules.value, "priority", null)
           prefix   = lookup(rules.value, "prefix", null)
-          status   = lookup(rules.value, "status", null)
+          status   = rules.value.status
 
           dynamic "destination" {
             for_each = length(keys(lookup(rules.value, "destination", {}))) == 0 ? [] : [lookup(rules.value, "destination", {})]
 
             content {
-              bucket             = lookup(destination.value, "bucket", null)
+              bucket             = destination.value.bucket
               storage_class      = lookup(destination.value, "storage_class", null)
               replica_kms_key_id = lookup(destination.value, "replica_kms_key_id", null)
               account_id         = lookup(destination.value, "account_id", null)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
For required arguments instead of doing a lookup, variables are fixed. I fixed such arguments which are required instead of lookup.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Makes it easier to not miss these variables to set. Also, keeps the module uniform as other variables are set like this.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
None

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Plan against the [example/s3-replication](https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/tree/master/examples/s3-replication).