### PR TITLE
chore: Allow 0.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ module "s3_bucket" {
 
 | Name | Version |
 |------|---------|
-| terraform | ~> 0.12.6 |
+| terraform | >= 0.12.6, < 0.14 |
 | aws | ~> 2.35 |
 
 ## Providers

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">= 0.12.6"
 
   required_providers {
     aws = "~> 2.35"

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.6"
+  required_version = ">= 0.12.6, < 0.14"
 
   required_providers {
     aws = "~> 2.35"


### PR DESCRIPTION
## Description
Update the required version block to allow 0.13 usage

## Motivation and Context
This module cannot be used with the 0.13 versions of terraform (beta, or the upcoming GA), this modifies the version so that it can at least be used. However, there are other changes that might be desirable, such as deprecating the `create_bucket` argument now that module count will be available.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
Forked this repo, changed the file, and ran through loading the module, changing count, and changing for_each.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
