### PR TITLE
feat: support a list of rules instead of a single rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ module "s3_bucket" {
 | block\_public\_policy | Whether Amazon S3 should block public bucket policies for this bucket. | `bool` | `false` | no |
 | bucket | (Optional, Forces new resource) The name of the bucket. If omitted, Terraform will assign a random, unique name. | `string` | `null` | no |
 | bucket\_prefix | (Optional, Forces new resource) Creates a unique bucket name beginning with the specified prefix. Conflicts with bucket. | `string` | `null` | no |
-| cors\_rules | List containing rules for Cross-Origin Resource Sharing. | `any` | `{}` | no |
+| cors\_rule | List of maps containing rules for Cross-Origin Resource Sharing. | `list(any)` | `[]` | no |
 | create\_bucket | Controls if S3 bucket should be created | `bool` | `true` | no |
 | force\_destroy | (Optional, Default:false ) A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable. | `bool` | `false` | no |
 | ignore\_public\_acls | Whether Amazon S3 should ignore public ACLs for this bucket. | `bool` | `false` | no |

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ module "s3_bucket" {
 | block\_public\_policy | Whether Amazon S3 should block public bucket policies for this bucket. | `bool` | `false` | no |
 | bucket | (Optional, Forces new resource) The name of the bucket. If omitted, Terraform will assign a random, unique name. | `string` | `null` | no |
 | bucket\_prefix | (Optional, Forces new resource) Creates a unique bucket name beginning with the specified prefix. Conflicts with bucket. | `string` | `null` | no |
-| cors\_rule | Map containing a rule of Cross-Origin Resource Sharing. | `any` | `{}` | no |
+| cors\_rules | List containing rules for Cross-Origin Resource Sharing. | `any` | `{}` | no |
 | create\_bucket | Controls if S3 bucket should be created | `bool` | `true` | no |
 | force\_destroy | (Optional, Default:false ) A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable. | `bool` | `false` | no |
 | ignore\_public\_acls | Whether Amazon S3 should ignore public ACLs for this bucket. | `bool` | `false` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -92,13 +92,21 @@ module "s3_bucket" {
     target_prefix = "log/"
   }
 
-  cors_rules = [{
-    allowed_methods = ["PUT", "POST"]
-    allowed_origins = ["https://modules.tf", "https://terraform-aws-modules.modules.tf"]
-    allowed_headers = ["*"]
-    expose_headers  = ["ETag"]
-    max_age_seconds = 3000
-  }]
+  cors_rule = [
+    {
+      allowed_methods = ["PUT", "POST"]
+      allowed_origins = ["https://modules.tf", "https://terraform-aws-modules.modules.tf"]
+      allowed_headers = ["*"]
+      expose_headers  = ["ETag"]
+      max_age_seconds = 3000
+      }, {
+      allowed_methods = ["PUT"]
+      allowed_origins = ["https://example.com"]
+      allowed_headers = ["*"]
+      expose_headers  = ["ETag"]
+      max_age_seconds = 3000
+    }
+  ]
 
   lifecycle_rule = [
     {

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -92,13 +92,13 @@ module "s3_bucket" {
     target_prefix = "log/"
   }
 
-  cors_rule = {
+  cors_rules = [{
     allowed_methods = ["PUT", "POST"]
     allowed_origins = ["https://modules.tf", "https://terraform-aws-modules.modules.tf"]
     allowed_headers = ["*"]
     expose_headers  = ["ETag"]
     max_age_seconds = 3000
-  }
+  }]
 
   lifecycle_rule = [
     {

--- a/main.tf
+++ b/main.tf
@@ -22,7 +22,7 @@ resource "aws_s3_bucket" "this" {
   }
 
   dynamic "cors_rule" {
-    for_each = length(keys(var.cors_rule)) == 0 ? [] : [var.cors_rule]
+    for_each = var.cors_rules
 
     content {
       allowed_methods = cors_rule.value.allowed_methods

--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ resource "aws_s3_bucket" "this" {
   }
 
   dynamic "cors_rule" {
-    for_each = var.cors_rules
+    for_each = var.cors_rule
 
     content {
       allowed_methods = cors_rule.value.allowed_methods

--- a/variables.tf
+++ b/variables.tf
@@ -76,8 +76,8 @@ variable "website" {
   default     = {}
 }
 
-variable "cors_rules" {
-  description = "List containing rules for Cross-Origin Resource Sharing."
+variable "cors_rule" {
+  description = "List of maps containing rules for Cross-Origin Resource Sharing."
   type        = list(any)
   default     = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -82,10 +82,10 @@ variable "website" {
   default     = {}
 }
 
-variable "cors_rule" {
-  description = "Map containing a rule of Cross-Origin Resource Sharing."
-  type        = any # should be `map`, but it produces an error "all map elements must have the same type"
-  default     = {}
+variable "cors_rules" {
+  description = "List containing rules for Cross-Origin Resource Sharing."
+  type        = list(any)
+  default     = []
 }
 
 variable "versioning" {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Modify CORS to support multiple rules instead of a single rule
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
When importing an existing bucket the module was attempting to remove all but one of the rules.
## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
Yes
<!-- If so, please provide an explanation why it is necessary. -->
Object to Array. It is possible to be backwards compatible, however, since the syntax is as simple as adding brackets there is little reason to add additional code.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Applying on an existing resource
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
