### PR TITLE
feat: Creating SNS/SQS policies should be optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,14 +84,14 @@ module "s3_bucket" {
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.6, < 0.14 |
-| aws | >= 3.0, < 4.0 |
+| terraform | >= 0.12.6 |
+| aws | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 3.0, < 4.0 |
+| aws | >= 3.0 |
 
 ## Inputs
 

--- a/examples/notification/README.md
+++ b/examples/notification/README.md
@@ -19,18 +19,18 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.6, < 0.14 |
-| aws | >= 3.0, < 4.0 |
-| null | ~> 2 |
-| random | ~> 2 |
+| terraform | >= 0.12.6 |
+| aws | >= 3.0 |
+| null | >= 2 |
+| random | >= 2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 3.0, < 4.0 |
-| null | ~> 2 |
-| random | ~> 2 |
+| aws | >= 3.0 |
+| null | >= 2 |
+| random | >= 2 |
 
 ## Inputs
 

--- a/examples/notification/main.tf
+++ b/examples/notification/main.tf
@@ -79,7 +79,7 @@ resource "aws_sqs_queue" "this" {
 # SQS policy created outside of the module
 data "aws_iam_policy_document" "sqs_external" {
   statement {
-    effect = "Allow"
+    effect  = "Allow"
     actions = ["sqs:SendMessage"]
 
     principals {

--- a/examples/notification/main.tf
+++ b/examples/notification/main.tf
@@ -76,6 +76,26 @@ resource "aws_sqs_queue" "this" {
   name  = "${random_pet.this.id}-${count.index}"
 }
 
+# SQS policy created outside of the module
+data "aws_iam_policy_document" "sqs_external" {
+  statement {
+    effect = "Allow"
+    actions = ["sqs:SendMessage"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["s3.amazonaws.com"]
+    }
+
+    resources = [aws_sqs_queue.this[0].arn]
+  }
+}
+
+resource "aws_sqs_queue_policy" "allow_external" {
+  queue_url = aws_sqs_queue.this[0].id
+  policy    = data.aws_iam_policy_document.sqs_external.json
+}
+
 module "all_notifications" {
   source = "../../modules/notification"
 
@@ -129,4 +149,6 @@ module "all_notifications" {
     }
   }
 
+  # Creation of policy is handled outside of the module
+  create_sqs_policy = false
 }

--- a/examples/notification/versions.tf
+++ b/examples/notification/versions.tf
@@ -1,9 +1,9 @@
 terraform {
-  required_version = ">= 0.12.6, < 0.14"
+  required_version = ">= 0.12.6"
 
   required_providers {
-    aws    = ">= 3.0, < 4.0"
-    random = "~> 2"
-    null   = "~> 2"
+    aws    = ">= 3.0"
+    random = ">= 2"
+    null   = ">= 2"
   }
 }

--- a/examples/s3-replication/README.md
+++ b/examples/s3-replication/README.md
@@ -21,17 +21,17 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.6, < 0.14 |
-| aws | >= 3.0, < 4.0 |
-| random | ~> 2 |
+| terraform | >= 0.12.6 |
+| aws | >= 3.0 |
+| random | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 3.0, < 4.0 |
-| aws.replica | >= 3.0, < 4.0 |
-| random | ~> 2 |
+| aws | >= 3.0 |
+| aws.replica | >= 3.0 |
+| random | >= 2.0 |
 
 ## Inputs
 

--- a/examples/s3-replication/versions.tf
+++ b/examples/s3-replication/versions.tf
@@ -1,8 +1,8 @@
 terraform {
-  required_version = ">= 0.12.6, < 0.14"
+  required_version = ">= 0.12.6"
 
   required_providers {
-    aws    = ">= 3.0, < 4.0"
-    random = "~> 2"
+    aws    = ">= 3.0"
+    random = ">= 2.0"
   }
 }

--- a/modules/notification/README.md
+++ b/modules/notification/README.md
@@ -7,15 +7,15 @@ Creates S3 bucket notification resource with all supported types of deliveries: 
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.6, < 0.14 |
-| aws | >= 3.0, < 4.0 |
-| random | ~> 2 |
+| terraform | >= 0.12.6 |
+| aws | >= 3.0 |
+| random | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | >= 3.0, < 4.0 |
+| aws | >= 3.0 |
 
 ## Inputs
 
@@ -24,6 +24,8 @@ Creates S3 bucket notification resource with all supported types of deliveries: 
 | bucket | Name of S3 bucket to use | `string` | `""` | no |
 | bucket\_arn | ARN of S3 bucket to use in policies | `string` | `null` | no |
 | create | Whether to create this resource or not? | `bool` | `true` | no |
+| create\_sns\_policy | Whether to create a policy for SNS permissions or not? | `bool` | `true` | no |
+| create\_sqs\_policy | Whether to create a policy for SQS permissions or not? | `bool` | `true` | no |
 | lambda\_notifications | Map of S3 bucket notifications to Lambda function | `any` | `{}` | no |
 | sns\_notifications | Map of S3 bucket notifications to SNS topic | `any` | `{}` | no |
 | sqs\_notifications | Map of S3 bucket notifications to SQS queue | `any` | `{}` | no |

--- a/modules/notification/main.tf
+++ b/modules/notification/main.tf
@@ -74,7 +74,7 @@ data "aws_arn" "queue" {
 }
 
 data "aws_iam_policy_document" "sqs" {
-  for_each = var.create_sqs_policy ? var.sqs_notifications : {}
+  for_each = var.create_sqs_policy ? var.sqs_notifications : tomap({})
 
   statement {
     sid = "AllowSQSS3BucketNotification"
@@ -101,7 +101,7 @@ data "aws_iam_policy_document" "sqs" {
 }
 
 resource "aws_sqs_queue_policy" "allow" {
-  for_each = var.create_sqs_policy ? var.sqs_notifications : {}
+  for_each = var.create_sqs_policy ? var.sqs_notifications : tomap({})
 
   queue_url = lookup(each.value, "queue_id", lookup(local.queue_ids, each.key, null))
   policy    = data.aws_iam_policy_document.sqs[each.key].json
@@ -109,7 +109,7 @@ resource "aws_sqs_queue_policy" "allow" {
 
 # SNS Topic
 data "aws_iam_policy_document" "sns" {
-  for_each = var.create_sns_policy ? var.sns_notifications : {}
+  for_each = var.create_sns_policy ? var.sns_notifications : tomap({})
 
   statement {
     sid = "AllowSNSS3BucketNotification"
@@ -136,7 +136,7 @@ data "aws_iam_policy_document" "sns" {
 }
 
 resource "aws_sns_topic_policy" "allow" {
-  for_each = var.create_sns_policy ? var.sns_notifications : {}
+  for_each = var.create_sns_policy ? var.sns_notifications : tomap({})
 
   arn    = each.value.topic_arn
   policy = data.aws_iam_policy_document.sns[each.key].json

--- a/modules/notification/main.tf
+++ b/modules/notification/main.tf
@@ -101,7 +101,7 @@ data "aws_iam_policy_document" "sqs" {
 }
 
 resource "aws_sqs_queue_policy" "allow" {
-  for_each = var.sqs_notifications
+  for_each = var.create_sqs_policy ? var.sqs_notifications : {}
 
   queue_url = lookup(each.value, "queue_id", lookup(local.queue_ids, each.key, null))
   policy    = data.aws_iam_policy_document.sqs[each.key].json
@@ -136,7 +136,7 @@ data "aws_iam_policy_document" "sns" {
 }
 
 resource "aws_sns_topic_policy" "allow" {
-  for_each = var.sns_notifications
+  for_each = var.create_sns_policy ? var.sns_notifications : {}
 
   arn    = each.value.topic_arn
   policy = data.aws_iam_policy_document.sns[each.key].json

--- a/modules/notification/main.tf
+++ b/modules/notification/main.tf
@@ -74,7 +74,7 @@ data "aws_arn" "queue" {
 }
 
 data "aws_iam_policy_document" "sqs" {
-  for_each = var.sqs_notifications
+  for_each = var.create_sqs_policy ? var.sqs_notifications : {}
 
   statement {
     sid = "AllowSQSS3BucketNotification"
@@ -109,7 +109,7 @@ resource "aws_sqs_queue_policy" "allow" {
 
 # SNS Topic
 data "aws_iam_policy_document" "sns" {
-  for_each = var.sns_notifications
+  for_each = var.create_sns_policy ? var.sns_notifications : {}
 
   statement {
     sid = "AllowSNSS3BucketNotification"

--- a/modules/notification/variables.tf
+++ b/modules/notification/variables.tf
@@ -30,18 +30,18 @@ variable "bucket_arn" {
 
 variable "lambda_notifications" {
   description = "Map of S3 bucket notifications to Lambda function"
-  type        = any # map(map(any)) is better, but Terraform 0.12.25 panics
+  type        = any
   default     = {}
 }
 
 variable "sqs_notifications" {
   description = "Map of S3 bucket notifications to SQS queue"
-  type        = any # map(map(any)) is better, but Terraform 0.12.25 panics
+  type        = any
   default     = {}
 }
 
 variable "sns_notifications" {
   description = "Map of S3 bucket notifications to SNS topic"
-  type        = any # map(map(any)) is better, but Terraform 0.12.25 panics
+  type        = any
   default     = {}
 }

--- a/modules/notification/variables.tf
+++ b/modules/notification/variables.tf
@@ -4,6 +4,18 @@ variable "create" {
   default     = true
 }
 
+variable "create_sns_policy" {
+  description = "Whether to create a policy for SNS permissions or not?"
+  type        = bool
+  default     = true
+}
+
+variable "create_sqs_policy" {
+  description = "Whether to create a policy for SQS permissions or not?"
+  type        = bool
+  default     = true
+}
+
 variable "bucket" {
   description = "Name of S3 bucket to use"
   type        = string

--- a/modules/notification/versions.tf
+++ b/modules/notification/versions.tf
@@ -1,8 +1,8 @@
 terraform {
-  required_version = ">= 0.12.6, < 0.14"
+  required_version = ">= 0.12.6"
 
   required_providers {
-    aws    = ">= 3.0, < 4.0"
-    random = "~> 2"
+    aws    = ">= 3.0"
+    random = ">= 2.0"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,7 @@
 terraform {
-  required_version = ">= 0.12.6, < 0.14"
+  required_version = ">= 0.12.6"
 
   required_providers {
-    aws = ">= 3.0, < 4.0"
+    aws = ">= 3.0"
   }
 }


### PR DESCRIPTION
## Description
Make the creation of SNS/SQS policies conditional based on two new variables, `create_sns_policy` and `create_sqs_policy`.

## Motivation and Context
We have a use case (as I'm sure others do) where we need to send S3 bucket notifications to an external account that we don't control, and so we can't create the related SNS/SQS policies in that account (and they aren't necessary).  The rest of the notification setup is valid when using the external resource ARNs, however.

## Breaking Changes
None; the variables default to `true` so behavior will be the same.

## How Has This Been Tested?
```sh
$ terraform -v
Terraform v0.12.29
+ provider.aws v3.10.0
+ provider.null v2.1.2
+ provider.random v2.3.0
```

Using the module as published failed to apply the notification due to the inability create the policy, so I added it manually and imported it.  This snippet...:
```
module "redacted-bucket" {
  source  = "terraform-aws-modules/s3-bucket/aws"
  version = "v1.15.0"

  bucket        = "redacted-bucket"
  acl           = "private"
  force_destroy = false

  tags = {
    creator     = "terraform"
  }

  versioning = {
    enabled = false
  }

  # S3 bucket-level Public Access Block configuration
  block_public_acls       = true
  block_public_policy     = true
  ignore_public_acls      = true
  restrict_public_buckets = true
}

module "redacted-bucket-notifications" {
  source  = "terraform-aws-modules/s3-bucket/aws//modules/notification"

  bucket            = module.redacted-bucket.this_s3_bucket_id

  # Common error - Error putting S3 notification configuration: InvalidArgument: Configuration is ambiguously defined. Cannot have overlapping suffixes in two rules if the prefixes are overlapping for the same event type.

  sqs_notifications = {
    sqs1 = {
      queue_arn     = "redacted-queue-arn"
      events        = ["s3:ObjectCreated:Put"]
      filter_suffix = ".gz"
    }
  }
}
```

... results in this plan:
```
Terraform will perform the following actions:

  # module.redacted-bucket-notifications.aws_sqs_queue_policy.allow["sqs1"] will be created
  + resource "aws_sqs_queue_policy" "allow" {
      + id        = (known after apply)
      + policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sqs:SendMessage"
                      + Condition = {
                          + ArnEquals = {
                              + aws:SourceArn = "arn:aws:s3:::redacted-bucket"
                            }
                        }
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "s3.amazonaws.com"
                        }
                      + Resource  = "redacted-queue-arn"
                      + Sid       = "AllowSQSS3BucketNotification"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + queue_url = "redacted-queue-url"
    }

Plan: 1 to add, 0 to change, 0 to destroy.
```

Changing the module to use this branch like so...:
```
module "redacted-bucket-notifications" {
  source  = "github.com/bmurphey/terraform-aws-s3-bucket//modules/notification?ref=optional-create-policy"

  bucket                   = module.redacted-bucket.this_s3_bucket_id
  create_sqs_policy = false

  # Common error - Error putting S3 notification configuration: InvalidArgument: Configuration is ambiguously defined. Cannot have overlapping suffixes in two rules if the prefixes are overlapping for the same event type.

  sqs_notifications = {
    sqs1 = {
      queue_arn     = "redacted-queue-arn"
      events        = ["s3:ObjectCreated:Put"]
      filter_suffix = ".gz"
    }
  }
}
```

... results in `No changes. Infrastructure is up-to-date.`.  It appears to me that the SNS policy is created in the same manner, so I added a variable to make that policy creation conditional as well, but that hasn't been tested.