### PR TITLE
Change ELB Log Delivery Policy to use ARN output

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -257,7 +257,7 @@ data "aws_iam_policy_document" "elb_log_delivery" {
     ]
 
     resources = [
-      "arn:aws:s3:::${aws_s3_bucket.this[0].id}/*",
+      "${aws_s3_bucket.this[0].arn}/*",
     ]
   }
 }


### PR DESCRIPTION
## Description
The ELB log delivery policy creates an ARN as opposed to using the S3 resources ARN output. These results in the policy not working in gov cloud. 
https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/issues/59

## Motivation and Context


## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
I test this change in gov cloud. 
