### PR TITLE
feat: reimplemented bucket policy to hold multiple policy statements

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -48,13 +48,24 @@ data "aws_iam_policy_document" "bucket_policy" {
   }
 }
 
+module "billing_bucket" {
+  source = "../../"
+
+  bucket                             = "billing-${random_pet.this.id}"
+  force_destroy                      = true
+  attach_billing_log_delivery_policy = true
+}
+
 module "log_bucket" {
   source = "../../"
 
-  bucket                         = "logs-${random_pet.this.id}"
-  acl                            = "log-delivery-write"
-  force_destroy                  = true
-  attach_elb_log_delivery_policy = true
+  bucket                                = "logs-${random_pet.this.id}"
+  acl                                   = "log-delivery-write"
+  force_destroy                         = true
+  attach_elb_log_delivery_policy        = true
+  attach_redshift_log_delivery_policy   = true
+  redshift_service_account_regions      = ["us-east-1", "eu-central-1"]
+  attach_cloudtrail_log_delivery_policy = true
 }
 
 module "cloudfront_log_bucket" {

--- a/main.tf
+++ b/main.tf
@@ -239,11 +239,6 @@ data "aws_elb_service_account" "this" {
   count = var.create_bucket && var.attach_elb_log_delivery_policy ? 1 : 0
 }
 
-# AWS Cloudtrail account
-data "aws_cloudtrail_service_account" "this" {
-  count = var.create_bucket && var.attach_cloudtrail_log_delivery_policy ? 1 : 0
-}
-
 # AWS Redshift account
 data "aws_redshift_service_account" "this" {
   count  = var.create_bucket && var.attach_redshift_log_delivery_policy ? local.redshift_region_count : 0
@@ -304,8 +299,8 @@ data "aws_iam_policy_document" "generated_policy" {
     iterator = item
     content {
       principals {
-        identifiers = data.aws_cloudtrail_service_account.this.*.arn
-        type        = "AWS"
+        identifiers = ["cloudtrail.amazonaws.com"]
+        type        = "Service"
       }
       effect = "Allow"
       actions = [
@@ -324,8 +319,8 @@ data "aws_iam_policy_document" "generated_policy" {
     iterator = item
     content {
       principals {
-        identifiers = data.aws_cloudtrail_service_account.this.*.arn
-        type        = "AWS"
+        identifiers = ["cloudtrail.amazonaws.com"]
+        type        = "Service"
       }
       effect    = "Allow"
       actions   = ["s3:GetBucketAcl"]

--- a/variables.tf
+++ b/variables.tf
@@ -10,6 +10,30 @@ variable "attach_elb_log_delivery_policy" {
   default     = false
 }
 
+variable "attach_cloudtrail_log_delivery_policy" {
+  description = "Controls if S3 bucket should have Cloudtrail log delivery policy attached"
+  type        = bool
+  default     = false
+}
+
+variable "attach_redshift_log_delivery_policy" {
+  description = "Controls if S3 bucket should have Redshift log delivery policy attached"
+  type        = bool
+  default     = false
+}
+
+variable "redshift_service_account_regions" {
+  description = "Controls where Reshift log delivery policy should be configured only for current region or for other regions as well"
+  type        = list(string)
+  default     = []
+}
+
+variable "attach_billing_log_delivery_policy" {
+  description = "Controls if S3 bucket should have Billing report delivery policy attached"
+  type        = bool
+  default     = false
+}
+
 variable "attach_policy" {
   description = "Controls if S3 bucket should have bucket policy attached (set to `true` to use value of `policy` as bucket policy)"
   type        = bool


### PR DESCRIPTION
## Description
- added policy for redshift audit logs
- added policy for cloudtrail
- added policy for billing reports


## Motivation and Context
added support for 
 - redshift audit logs
 - cloudtrail
 - billing reports
 - now bucket can hold multiple statements for different services 

## Breaking Changes
- should be compatible with previous version


## How Has This Been Tested?
### Redshift policy example
```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Sid": "",
            "Effect": "Allow",
            "Principal": {
                "AWS": [
                    "arn:aws:iam::053454850223:user/logs",
                    "arn:aws:iam::193672423079:user/logs"
                ]
            },
            "Action": "s3:GetBucketAcl",
            "Resource": "arn:aws:s3:::logs-kind-liger"
        },
        {
            "Sid": "",
            "Effect": "Allow",
            "Principal": {
                "AWS": [
                    "arn:aws:iam::053454850223:user/logs",
                    "arn:aws:iam::193672423079:user/logs"
                ]
            },
            "Action": "s3:PutObject",
            "Resource": "arn:aws:s3:::logs-kind-liger/*",
            "Condition": {
                "StringEquals": {
                    "s3:x-amz-acl": "bucket-owner-full-control"
                }
            }
        }
    ]
}
```
### Cloudtrail policy example
```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Sid": "",
            "Effect": "Allow",
            "Principal": {
                "Service": "cloudtrail.amazonaws.com"
            },
            "Action": "s3:PutObject",
            "Resource": "arn:aws:s3:::logs-kind-liger/*",
            "Condition": {
                "StringEquals": {
                    "s3:x-amz-acl": "bucket-owner-full-control"
                }
            }
        },
        {
            "Sid": "",
            "Effect": "Allow",
            "Principal": {
                "Service": "cloudtrail.amazonaws.com"
            },
            "Action": "s3:GetBucketAcl",
            "Resource": "arn:aws:s3:::logs-kind-liger"
        }
    ]
}

```

### Billing policy example
```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Sid": "",
            "Effect": "Allow",
            "Principal": {
                "Service": "billingreports.amazonaws.com"
            },
            "Action": "s3:GetBucketAcl",
            "Resource": "arn:aws:s3:::billing-kind-liger"
        },
        {
            "Sid": "",
            "Effect": "Allow",
            "Principal": {
                "Service": "billingreports.amazonaws.com"
            },
            "Action": "s3:PutObject",
            "Resource": "arn:aws:s3:::billing-kind-liger/*"
        }
    ]
}
```

### Upgrade 
#### v1.9.0
```
~/w/a/d/t/e/complete ((v1.9.0)) > terraform apply -auto-approve
module.log_bucket.data.aws_elb_service_account.this[0]: Refreshing state...
random_pet.this: Creating...
random_pet.this: Creation complete after 0s [id=kind-liger]
aws_kms_key.objects: Creating...
aws_iam_role.this: Creating...
module.log_bucket.aws_s3_bucket.this[0]: Creating...
aws_kms_key.objects: Creation complete after 1s [id=e0af5f47-7415-4ec9-8d23-4d028e429679]
aws_iam_role.this: Creation complete after 1s [id=terraform-20201228163033680900000001]
data.aws_iam_policy_document.bucket_policy: Refreshing state...
module.log_bucket.aws_s3_bucket.this[0]: Creation complete after 3s [id=logs-kind-liger]
module.log_bucket.data.aws_iam_policy_document.elb_log_delivery[0]: Refreshing state...
module.log_bucket.aws_s3_bucket_policy.this[0]: Creating...
module.log_bucket.aws_s3_bucket_policy.this[0]: Creation complete after 0s [id=logs-kind-liger]
module.log_bucket.aws_s3_bucket_public_access_block.this[0]: Creating...
module.s3_bucket.aws_s3_bucket.this[0]: Creating...
module.log_bucket.aws_s3_bucket_public_access_block.this[0]: Creation complete after 1s [id=logs-kind-liger]
module.s3_bucket.aws_s3_bucket.this[0]: Creation complete after 10s [id=s3-bucket-kind-liger]
module.s3_bucket.aws_s3_bucket_policy.this[0]: Creating...
module.s3_bucket.aws_s3_bucket_policy.this[0]: Creation complete after 0s [id=s3-bucket-kind-liger]
module.s3_bucket.aws_s3_bucket_public_access_block.this[0]: Creating...
module.s3_bucket.aws_s3_bucket_public_access_block.this[0]: Creation complete after 1s [id=s3-bucket-kind-liger]

Apply complete! Resources: 9 added, 0 changed, 0 destroyed.

Outputs:

this_s3_bucket_arn = arn:aws:s3:::s3-bucket-kind-liger
this_s3_bucket_bucket_domain_name = s3-bucket-kind-liger.s3.amazonaws.com
this_s3_bucket_bucket_regional_domain_name = s3-bucket-kind-liger.s3.eu-central-1.amazonaws.com
this_s3_bucket_hosted_zone_id = Z21DNDUVLTQW6Q
this_s3_bucket_id = s3-bucket-kind-liger
this_s3_bucket_region = eu-central-1
this_s3_bucket_website_domain = s3-website.eu-central-1.amazonaws.com
this_s3_bucket_website_endpoint = s3-bucket-kind-liger.s3-website.eu-central-1.amazonaws.com
```

#### new version
```
~/w/a/d/t/e/complete (feature/reimplemented_bucket_policy) > terraform plan
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

random_pet.this: Refreshing state... [id=kind-liger]
aws_kms_key.objects: Refreshing state... [id=e0af5f47-7415-4ec9-8d23-4d028e429679]
aws_iam_role.this: Refreshing state... [id=terraform-20201228163033680900000001]
module.log_bucket.data.aws_elb_service_account.this[0]: Refreshing state...
module.log_bucket.aws_s3_bucket.this[0]: Refreshing state... [id=logs-kind-liger]
data.aws_canonical_user_id.current: Refreshing state...
module.log_bucket.data.aws_redshift_service_account.this[0]: Refreshing state...
module.log_bucket.data.aws_cloudtrail_service_account.this[0]: Refreshing state...
module.log_bucket.data.aws_redshift_service_account.this[1]: Refreshing state...
data.aws_iam_policy_document.bucket_policy: Refreshing state...
module.log_bucket.data.aws_iam_policy_document.generated_policy[0]: Refreshing state...
module.log_bucket.aws_s3_bucket_policy.this[0]: Refreshing state... [id=logs-kind-liger]
module.log_bucket.aws_s3_bucket_public_access_block.this[0]: Refreshing state... [id=logs-kind-liger]
module.s3_bucket.aws_s3_bucket.this[0]: Refreshing state... [id=s3-bucket-kind-liger]
module.s3_bucket.aws_s3_bucket_policy.this[0]: Refreshing state... [id=s3-bucket-kind-liger]
module.s3_bucket.aws_s3_bucket_public_access_block.this[0]: Refreshing state... [id=s3-bucket-kind-liger]

------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create
  ~ update in-place
 <= read (data resources)

Terraform will perform the following actions:

  # module.billing_bucket.data.aws_iam_policy_document.generated_policy[0] will be read during apply
  # (config refers to values not yet known)
 <= data "aws_iam_policy_document" "generated_policy"  {
      + id   = (known after apply)
      + json = (known after apply)

      + statement {
          + actions   = [
              + "s3:GetBucketAcl",
            ]
          + effect    = "Allow"
          + resources = [
              + (known after apply),
            ]

          + principals {
              + identifiers = [
                  + "billingreports.amazonaws.com",
                ]
              + type        = "Service"
            }
        }
      + statement {
          + actions   = [
              + "s3:PutObject",
            ]
          + effect    = "Allow"
          + resources = [
              + (known after apply),
            ]

          + principals {
              + identifiers = [
                  + "billingreports.amazonaws.com",
                ]
              + type        = "Service"
            }
        }
    }

  # module.billing_bucket.aws_s3_bucket.this[0] will be created
  + resource "aws_s3_bucket" "this" {
      + acceleration_status         = (known after apply)
      + acl                         = "private"
      + arn                         = (known after apply)
      + bucket                      = "billing-kind-liger"
      + bucket_domain_name          = (known after apply)
      + bucket_regional_domain_name = (known after apply)
      + force_destroy               = true
      + hosted_zone_id              = (known after apply)
      + id                          = (known after apply)
      + region                      = (known after apply)
      + request_payer               = (known after apply)
      + website_domain              = (known after apply)
      + website_endpoint            = (known after apply)

      + versioning {
          + enabled    = (known after apply)
          + mfa_delete = (known after apply)
        }
    }

  # module.billing_bucket.aws_s3_bucket_policy.this[0] will be created
  + resource "aws_s3_bucket_policy" "this" {
      + bucket = (known after apply)
      + id     = (known after apply)
      + policy = (known after apply)
    }

  # module.billing_bucket.aws_s3_bucket_public_access_block.this[0] will be created
  + resource "aws_s3_bucket_public_access_block" "this" {
      + block_public_acls       = false
      + block_public_policy     = false
      + bucket                  = (known after apply)
      + id                      = (known after apply)
      + ignore_public_acls      = false
      + restrict_public_buckets = false
    }

  # module.cloudfront_log_bucket.aws_s3_bucket.this[0] will be created
  + resource "aws_s3_bucket" "this" {
      + acceleration_status         = (known after apply)
      + acl                         = "private"
      + arn                         = (known after apply)
      + bucket                      = "cloudfront-logs-kind-liger"
      + bucket_domain_name          = (known after apply)
      + bucket_regional_domain_name = (known after apply)
      + force_destroy               = true
      + hosted_zone_id              = (known after apply)
      + id                          = (known after apply)
      + region                      = (known after apply)
      + request_payer               = (known after apply)
      + website_domain              = (known after apply)
      + website_endpoint            = (known after apply)

      + grant {
          + id          = "78d910d861adcded39fc2c12a151d14f2b69d8d4a33a435a2abd9bc8211146b7"
          + permissions = [
              + "FULL_CONTROL",
            ]
          + type        = "CanonicalUser"
        }
      + grant {
          + id          = "c4c1ede66af53448b93c283ce9448c4ba468c9432aa01d700d3878632f77d2d0"
          + permissions = [
              + "FULL_CONTROL",
            ]
          + type        = "CanonicalUser"
        }

      + versioning {
          + enabled    = (known after apply)
          + mfa_delete = (known after apply)
        }
    }

  # module.cloudfront_log_bucket.aws_s3_bucket_public_access_block.this[0] will be created
  + resource "aws_s3_bucket_public_access_block" "this" {
      + block_public_acls       = false
      + block_public_policy     = false
      + bucket                  = (known after apply)
      + id                      = (known after apply)
      + ignore_public_acls      = false
      + restrict_public_buckets = false
    }

  # module.log_bucket.aws_s3_bucket_policy.this[0] will be updated in-place
  ~ resource "aws_s3_bucket_policy" "this" {
        bucket = "logs-kind-liger"
        id     = "logs-kind-liger"
      ~ policy = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Action    = "s3:PutObject" -> "s3:GetBucketAcl"
                        Effect    = "Allow"
                        Principal = {
                            AWS = "arn:aws:iam::054676820928:root"
                        }
                      ~ Resource  = "arn:aws:s3:::logs-kind-liger/*" -> "arn:aws:s3:::logs-kind-liger"
                        Sid       = ""
                    },
                  + {
                      + Action    = "s3:PutObject"
                      + Condition = {
                          + StringEquals = {
                              + s3:x-amz-acl = "bucket-owner-full-control"
                            }
                        }
                      + Effect    = "Allow"
                      + Principal = {
                          + AWS = "arn:aws:iam::054676820928:root"
                        }
                      + Resource  = "arn:aws:s3:::logs-kind-liger/*"
                      + Sid       = ""
                    },
                  + {
                      + Action    = "s3:PutObject"
                      + Condition = {
                          + StringEquals = {
                              + s3:x-amz-acl = "bucket-owner-full-control"
                            }
                        }
                      + Effect    = "Allow"
                      + Principal = {
                          + AWS = "arn:aws:iam::035351147821:root"
                        }
                      + Resource  = "arn:aws:s3:::logs-kind-liger/*"
                      + Sid       = ""
                    },
                  + {
                      + Action    = "s3:GetBucketAcl"
                      + Effect    = "Allow"
                      + Principal = {
                          + AWS = "arn:aws:iam::035351147821:root"
                        }
                      + Resource  = "arn:aws:s3:::logs-kind-liger"
                      + Sid       = ""
                    },
                  + {
                      + Action    = "s3:GetBucketAcl"
                      + Effect    = "Allow"
                      + Principal = {
                          + AWS = [
                              + "arn:aws:iam::193672423079:user/logs",
                              + "arn:aws:iam::053454850223:user/logs",
                            ]
                        }
                      + Resource  = "arn:aws:s3:::logs-kind-liger"
                      + Sid       = ""
                    },
                  + {
                      + Action    = "s3:PutObject"
                      + Condition = {
                          + StringEquals = {
                              + s3:x-amz-acl = "bucket-owner-full-control"
                            }
                        }
                      + Effect    = "Allow"
                      + Principal = {
                          + AWS = [
                              + "arn:aws:iam::193672423079:user/logs",
                              + "arn:aws:iam::053454850223:user/logs",
                            ]
                        }
                      + Resource  = "arn:aws:s3:::logs-kind-liger/*"
                      + Sid       = ""
                    },
                ]
                Version   = "2012-10-17"
            }
        )
    }

  # module.s3_bucket.aws_s3_bucket.this[0] will be updated in-place
  ~ resource "aws_s3_bucket" "this" {
        acl                         = "private"
        arn                         = "arn:aws:s3:::s3-bucket-kind-liger"
        bucket                      = "s3-bucket-kind-liger"
        bucket_domain_name          = "s3-bucket-kind-liger.s3.amazonaws.com"
        bucket_regional_domain_name = "s3-bucket-kind-liger.s3.eu-central-1.amazonaws.com"
        force_destroy               = true
        hosted_zone_id              = "Z21DNDUVLTQW6Q"
        id                          = "s3-bucket-kind-liger"
        region                      = "eu-central-1"
        request_payer               = "BucketOwner"
        tags                        = {
            "Owner" = "Anton"
        }
        website_domain              = "s3-website.eu-central-1.amazonaws.com"
        website_endpoint            = "s3-bucket-kind-liger.s3-website.eu-central-1.amazonaws.com"

        cors_rule {
            allowed_headers = [
                "*",
            ]
            allowed_methods = [
                "PUT",
                "POST",
            ]
            allowed_origins = [
                "https://modules.tf",
                "https://terraform-aws-modules.modules.tf",
            ]
            expose_headers  = [
                "ETag",
            ]
            max_age_seconds = 3000
        }
      + cors_rule {
          + allowed_headers = [
              + "*",
            ]
          + allowed_methods = [
              + "PUT",
            ]
          + allowed_origins = [
              + "https://example.com",
            ]
          + expose_headers  = [
              + "ETag",
            ]
          + max_age_seconds = 3000
        }

        lifecycle_rule {
            abort_incomplete_multipart_upload_days = 0
            enabled                                = true
            id                                     = "log"
            prefix                                 = "log/"
            tags                                   = {
                "autoclean" = "true"
                "rule"      = "log"
            }

            expiration {
                days                         = 90
                expired_object_delete_marker = false
            }

            noncurrent_version_expiration {
                days = 30
            }

            transition {
                days          = 30
                storage_class = "ONEZONE_IA"
            }
            transition {
                days          = 60
                storage_class = "GLACIER"
            }
        }
        lifecycle_rule {
            abort_incomplete_multipart_upload_days = 7
            enabled                                = true
            id                                     = "log1"
            prefix                                 = "log1/"
            tags                                   = {}

            noncurrent_version_expiration {
                days = 300
            }

            noncurrent_version_transition {
                days          = 30
                storage_class = "STANDARD_IA"
            }
            noncurrent_version_transition {
                days          = 60
                storage_class = "ONEZONE_IA"
            }
            noncurrent_version_transition {
                days          = 90
                storage_class = "GLACIER"
            }
        }

        logging {
            target_bucket = "logs-kind-liger"
            target_prefix = "log/"
        }

        object_lock_configuration {
            object_lock_enabled = "Enabled"

            rule {
                default_retention {
                    days  = 0
                    mode  = "COMPLIANCE"
                    years = 5
                }
            }
        }

        server_side_encryption_configuration {
            rule {
                apply_server_side_encryption_by_default {
                    kms_master_key_id = "arn:aws:kms:eu-central-1:845191622527:key/e0af5f47-7415-4ec9-8d23-4d028e429679"
                    sse_algorithm     = "aws:kms"
                }
            }
        }

        versioning {
            enabled    = true
            mfa_delete = false
        }

        website {
            error_document = "error.html"
            index_document = "index.html"
            routing_rules  = jsonencode(
                [
                    {
                        Condition = {
                            KeyPrefixEquals = "docs/"
                        }
                        Redirect  = {
                            ReplaceKeyPrefixWith = "documents/"
                        }
                    },
                ]
            )
        }
    }

Plan: 5 to add, 2 to change, 0 to destroy.

------------------------------------------------------------------------

Note: You didn't specify an "-out" parameter to save this plan, so Terraform
can't guarantee that exactly these actions will be performed if
"terraform apply" is subsequently run.
```