### PR TITLE
chore: update documentation based on latest `terraform-docs` which includes module and resource sections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,29 @@
-.terraform
-terraform.tfstate
-*.tfstate*
-terraform.tfvars
+# Local .terraform directories
+**/.terraform/*
+
+# Terraform lockfile
+.terraform.lock.hcl
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Exclude all .tfvars files, which are likely to contain sentitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.43.0
+    rev: v1.45.0
     hooks:
       - id: terraform_fmt
       - id: terraform_docs
@@ -20,6 +20,6 @@ repos:
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v3.4.0
     hooks:
       - id: check-merge-conflict

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.45.0
+    rev: v1.46.0
     hooks:
       - id: terraform_fmt
       - id: terraform_docs

--- a/README.md
+++ b/README.md
@@ -93,6 +93,20 @@ module "s3_bucket" {
 |------|---------|
 | aws | >= 3.0 |
 
+## Modules
+
+No Modules.
+
+## Resources
+
+| Name |
+|------|
+| [aws_elb_service_account](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/data-sources/elb_service_account) |
+| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/data-sources/iam_policy_document) |
+| [aws_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/resources/s3_bucket) |
+| [aws_s3_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/resources/s3_bucket_policy) |
+| [aws_s3_bucket_public_access_block](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/resources/s3_bucket_public_access_block) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -135,7 +149,6 @@ module "s3_bucket" {
 | this\_s3\_bucket\_region | The AWS region this bucket resides in. |
 | this\_s3\_bucket\_website\_domain | The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records. |
 | this\_s3\_bucket\_website\_endpoint | The website endpoint, if the bucket is configured with a website. If not, this will be an empty string. |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/README.md
+++ b/README.md
@@ -103,9 +103,9 @@ No Modules.
 |------|
 | [aws_elb_service_account](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/data-sources/elb_service_account) |
 | [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/data-sources/iam_policy_document) |
-| [aws_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/resources/s3_bucket) |
 | [aws_s3_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/resources/s3_bucket_policy) |
 | [aws_s3_bucket_public_access_block](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/resources/s3_bucket_public_access_block) |
+| [aws_s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/resources/s3_bucket) |
 
 ## Inputs
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -40,6 +40,24 @@ Note that this example may create resources which cost money. Run `terraform des
 | aws | >= 3.0, < 4.0 |
 | random | ~> 2 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| cloudfront_log_bucket | ../../ |  |
+| log_bucket | ../../ |  |
+| s3_bucket | ../../ |  |
+
+## Resources
+
+| Name |
+|------|
+| [aws_canonical_user_id](https://registry.terraform.io/providers/hashicorp/aws/4.0/docs/data-sources/canonical_user_id) |
+| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/4.0/docs/data-sources/iam_policy_document) |
+| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/4.0/docs/resources/iam_role) |
+| [aws_kms_key](https://registry.terraform.io/providers/hashicorp/aws/4.0/docs/resources/kms_key) |
+| [random_pet](https://registry.terraform.io/providers/hashicorp/random/2/docs/resources/pet) |
+
 ## Inputs
 
 No input.
@@ -56,5 +74,4 @@ No input.
 | this\_s3\_bucket\_region | The AWS region this bucket resides in. |
 | this\_s3\_bucket\_website\_domain | The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records. |
 | this\_s3\_bucket\_website\_endpoint | The website endpoint, if the bucket is configured with a website. If not, this will be an empty string. |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/notification/README.md
+++ b/examples/notification/README.md
@@ -48,8 +48,8 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name |
 |------|
 | [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/data-sources/iam_policy_document) |
-| [aws_sqs_queue](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/resources/sqs_queue) |
 | [aws_sqs_queue_policy](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/resources/sqs_queue_policy) |
+| [aws_sqs_queue](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/resources/sqs_queue) |
 | [null_data_source](https://registry.terraform.io/providers/hashicorp/null/2/docs/data-sources/data_source) |
 | [null_resource](https://registry.terraform.io/providers/hashicorp/null/2/docs/resources/resource) |
 | [random_pet](https://registry.terraform.io/providers/hashicorp/random/2/docs/resources/pet) |

--- a/examples/notification/README.md
+++ b/examples/notification/README.md
@@ -32,6 +32,28 @@ Note that this example may create resources which cost money. Run `terraform des
 | null | >= 2 |
 | random | >= 2 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| all_notifications | ../../modules/notification |  |
+| lambda_function1 | terraform-aws-modules/lambda/aws | ~> 1.0 |
+| lambda_function2 | terraform-aws-modules/lambda/aws | ~> 1.0 |
+| s3_bucket | ../../ |  |
+| sns_topic1 | terraform-aws-modules/cloudwatch/aws//examples/fixtures/aws_sns_topic |  |
+| sns_topic2 | terraform-aws-modules/cloudwatch/aws//examples/fixtures/aws_sns_topic |  |
+
+## Resources
+
+| Name |
+|------|
+| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/data-sources/iam_policy_document) |
+| [aws_sqs_queue](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/resources/sqs_queue) |
+| [aws_sqs_queue_policy](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/resources/sqs_queue_policy) |
+| [null_data_source](https://registry.terraform.io/providers/hashicorp/null/2/docs/data-sources/data_source) |
+| [null_resource](https://registry.terraform.io/providers/hashicorp/null/2/docs/resources/resource) |
+| [random_pet](https://registry.terraform.io/providers/hashicorp/random/2/docs/resources/pet) |
+
 ## Inputs
 
 No input.
@@ -48,5 +70,4 @@ No input.
 | this\_s3\_bucket\_region | The AWS region this bucket resides in. |
 | this\_s3\_bucket\_website\_domain | The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records. |
 | this\_s3\_bucket\_website\_endpoint | The website endpoint, if the bucket is configured with a website. If not, this will be an empty string. |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/s3-replication/README.md
+++ b/examples/s3-replication/README.md
@@ -33,6 +33,24 @@ Note that this example may create resources which cost money. Run `terraform des
 | aws.replica | >= 3.0 |
 | random | >= 2.0 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| replica_bucket | ../../ |  |
+| s3_bucket | ../../ |  |
+
+## Resources
+
+| Name |
+|------|
+| [aws_caller_identity](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/data-sources/caller_identity) |
+| [aws_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/resources/iam_policy) |
+| [aws_iam_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/resources/iam_policy_attachment) |
+| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/resources/iam_role) |
+| [aws_kms_key](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/resources/kms_key) |
+| [random_pet](https://registry.terraform.io/providers/hashicorp/random/2.0/docs/resources/pet) |
+
 ## Inputs
 
 No input.
@@ -49,5 +67,4 @@ No input.
 | this\_s3\_bucket\_region | The AWS region this bucket resides in. |
 | this\_s3\_bucket\_website\_domain | The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records. |
 | this\_s3\_bucket\_website\_endpoint | The website endpoint, if the bucket is configured with a website. If not, this will be an empty string. |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/s3-replication/README.md
+++ b/examples/s3-replication/README.md
@@ -45,8 +45,8 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name |
 |------|
 | [aws_caller_identity](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/data-sources/caller_identity) |
-| [aws_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/resources/iam_policy) |
 | [aws_iam_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/resources/iam_policy_attachment) |
+| [aws_iam_policy](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/resources/iam_policy) |
 | [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/resources/iam_role) |
 | [aws_kms_key](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/resources/kms_key) |
 | [random_pet](https://registry.terraform.io/providers/hashicorp/random/2.0/docs/resources/pet) |

--- a/modules/notification/README.md
+++ b/modules/notification/README.md
@@ -17,6 +17,21 @@ Creates S3 bucket notification resource with all supported types of deliveries: 
 |------|---------|
 | aws | >= 3.0 |
 
+## Modules
+
+No Modules.
+
+## Resources
+
+| Name |
+|------|
+| [aws_arn](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/data-sources/arn) |
+| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/data-sources/iam_policy_document) |
+| [aws_lambda_permission](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/resources/lambda_permission) |
+| [aws_s3_bucket_notification](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/resources/s3_bucket_notification) |
+| [aws_sns_topic_policy](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/resources/sns_topic_policy) |
+| [aws_sqs_queue_policy](https://registry.terraform.io/providers/hashicorp/aws/3.0/docs/resources/sqs_queue_policy) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -35,5 +50,4 @@ Creates S3 bucket notification resource with all supported types of deliveries: 
 | Name | Description |
 |------|-------------|
 | this\_s3\_bucket\_notification\_id | ID of S3 bucket |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->


### PR DESCRIPTION
## Description
- update documentation based on latest `terraform-docs` which includes module and resource sections
- `.gitignore` updated using GitHub provided default standard + 0.14 lockfile ignore

## Motivation and Context
- these are two new sections provided by [`terraform-docs` now](https://github.com/terraform-docs/terraform-docs/releases/tag/v0.11.0)

## Breaking Changes
No

## How Has This Been Tested?
N/A
