### PR TITLE
chore: Updated string interpolation in resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -326,7 +326,7 @@ data "aws_iam_policy_document" "lb_log_delivery" {
     ]
 
     resources = [
-      "${aws_s3_bucket.this[0].arn}",
+      aws_s3_bucket.this[0].arn,
     ]
 
   }


### PR DESCRIPTION
## Description
Removing "${ sequence from the start and the }" aws_s3_bucket.this[0].arn to silence the warning about non-constant expressions provided via interpolation syntax

## Motivation and Context
Tired of the following message:
  Terraform 0.11 and earlier required all non-constant expressions to be
  provided via interpolation syntax, but this pattern is now deprecated. To
  silence this warning, remove the "${ sequence from the start and the }"
  sequence from the end of this expression, leaving just the inner expression.

## Breaking Changes
Does this break backwards compatibility with the current major version? **No**


## How Has This Been Tested?
- I did this change locally and applied the infrastructure update referencing the local version of the code. Warning didn't show up
