### PR TITLE
fix: Always send `filter` map in replication config

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -172,8 +172,16 @@ resource "aws_s3_bucket" "this" {
             }
           }
 
+          # Send empty map if `filter` is an empty map or absent entirely
           dynamic "filter" {
-            for_each = length(keys(lookup(rules.value, "filter", {}))) == 0 ? [] : [lookup(rules.value, "filter", {})]
+            for_each = length(keys(lookup(rules.value, "filter", {}))) == 0 ? [{}] : []
+
+            content {}
+          }
+
+          # Send `filter` if it is present and has at least one field
+          dynamic "filter" {
+            for_each = length(keys(lookup(rules.value, "filter", {}))) != 0 ? [lookup(rules.value, "filter", {})] : []
 
             content {
               prefix = lookup(filter.value, "prefix", null)


### PR DESCRIPTION
## Description
Send an empty `filter` map if no (or empty) `filter` was specified in `replication_configuration`.

(I'm not a Terraform expert so I'm not sure if the way I've done it is the best 😅)

## Motivation and Context
In the absence of at least an empty `filter` map if no filter was specified in a rule, `terraform apply` gives the following error for multi-destination S3 replication rules. See [this](https://github.com/hashicorp/terraform-provider-aws/issues/16546) `terraform-provider-aws` issue for additional context.

`Number of distinct destination bucket ARNs cannot exceed 1`

## Breaking Changes
Does not break backwards compatibility with the current major version.

## How Has This Been Tested?
- [x]  I have tested and validated these changes using one or more of the provided `examples/*` projects.
- Tested using the `S3 bucket with Cross-Region Replication (CRR) enabled` example.
- Tweaked the example to replicate `s3_bucket` to two replica buckets in the same region (one replication rule without a filter specified).
- Observed the `Number of distinct destination bucket ARNs cannot exceed 1` error with unmodified code and successful application with modifications.