### PR TITLE
fix: Always send `filter` map in replication config

### DIFF
--- a/examples/s3-replication/main.tf
+++ b/examples/s3-replication/main.tf
@@ -58,7 +58,7 @@ module "s3_bucket" {
 
     rules = [
       {
-        id       = "foo"
+        id       = "something-with-kms-and-filter"
         status   = "Enabled"
         priority = 10
 
@@ -86,15 +86,9 @@ module "s3_bucket" {
         }
       },
       {
-        id       = "bar"
+        id       = "something-with-filter"
         status   = "Enabled"
         priority = 20
-
-        destination = {
-          bucket        = "arn:aws:s3:::${local.destination_bucket_name}"
-          storage_class = "STANDARD"
-        }
-
 
         filter = {
           prefix = "two"
@@ -103,8 +97,34 @@ module "s3_bucket" {
           }
         }
 
+        destination = {
+          bucket        = "arn:aws:s3:::${local.destination_bucket_name}"
+          storage_class = "STANDARD"
+        }
       },
+      {
+        id       = "everything-with-filter"
+        status   = "Enabled"
+        priority = 30
 
+        filter = {
+          prefix = ""
+        }
+
+        destination = {
+          bucket        = "arn:aws:s3:::${local.destination_bucket_name}"
+          storage_class = "STANDARD"
+        }
+      },
+      {
+        id     = "everything-without-filters"
+        status = "Enabled"
+
+        destination = {
+          bucket        = "arn:aws:s3:::${local.destination_bucket_name}"
+          storage_class = "STANDARD"
+        }
+      },
     ]
   }
 

--- a/main.tf
+++ b/main.tf
@@ -172,8 +172,16 @@ resource "aws_s3_bucket" "this" {
             }
           }
 
+          # Send empty map if `filter` is an empty map or absent entirely
           dynamic "filter" {
-            for_each = length(keys(lookup(rules.value, "filter", {}))) == 0 ? [] : [lookup(rules.value, "filter", {})]
+            for_each = length(keys(lookup(rules.value, "filter", {}))) == 0 ? [{}] : []
+
+            content {}
+          }
+
+          # Send `filter` if it is present and has at least one field
+          dynamic "filter" {
+            for_each = length(keys(lookup(rules.value, "filter", {}))) != 0 ? [lookup(rules.value, "filter", {})] : []
 
             content {
               prefix = lookup(filter.value, "prefix", null)


### PR DESCRIPTION
Completely based on #104

Fixes #104 