### PR TITLE
Fix code to replication_configuration var have possibility be null

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -123,7 +123,7 @@ resource "aws_s3_bucket" "this" {
 
   # Max 1 block - replication_configuration
   dynamic "replication_configuration" {
-    for_each = length(keys(var.replication_configuration)) == 0 ? [] : [var.replication_configuration]
+    for_each = try(length(keys(var.replication_configuration)), 0) == 0 ? [] : [var.replication_configuration]
 
     content {
       role = replication_configuration.value.role


### PR DESCRIPTION
## Description
Inside replication_configuration dynamic module, i have a try in for_each expression, to evaluate the expression and returns 0 if the expression fails. The expression will fail if the variable is null

## Motivation and Context
I want add replication based in variable. So if variable is true, add the configuration, if it's false put the replication null. The problem is the for_each expression don't accept null.

`╷
│ Error: Invalid function argument
│ 
│   on ../../modules/s3/main.tf line 126, in resource "aws_s3_bucket" "this":
│  126:     for_each = length(keys(var.replication_configuration)) == 0 ? [] : [var.replication_configuration]
│     ├────────────────
│     │ var.replication_configuration is null
│ 
│ Invalid value for "inputMap" parameter: argument must not be null.
╵
Error running command: terraform plan -input=false
`

if i put the {} value if i don't want replication i will get the following error:

` 
The true and false result expressions must have consistent types. The given
expressions are object and object, respectively.
`

With this, i can put null if i don't want replication. I can use this configuration:

`
s3_crr_config = var.enable ?  {
    role = <role_arn>
    rules = [
      {
        id     = "replicate-all"
        status = "Enabled"
        delete_marker_replication_status = "Enabled"
        filter = {}
        destination = {
          bucket        = <bucket>
          storage_class = "GLACIER"
          account_id = <account>
          access_control_translation = {
            owner = "Destination"
          }
        }
      },
    ]
  } : null
`
