### PR TITLE
feat: Replace hardcoded cloudfront canonical user ID in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ inputs = {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.50 |
 
 ## Providers

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ inputs = {
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.50 |
 
 ## Providers

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -29,15 +29,15 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.50 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.60 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.50 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.60 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules
@@ -56,6 +56,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | [aws_kms_key.objects](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
 | [aws_canonical_user_id.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/canonical_user_id) | data source |
+| [aws_cloudfront_log_delivery_canonical_user_id.cloudfront](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/cloudfront_log_delivery_canonical_user_id) | data source |
 | [aws_iam_policy_document.bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -29,7 +29,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.60 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -4,6 +4,8 @@ locals {
 
 data "aws_canonical_user_id" "current" {}
 
+data "aws_cloudfront_log_delivery_canonical_user_id" "cloudfront" {}
+
 resource "random_pet" "this" {
   length = 2
 }
@@ -71,8 +73,7 @@ module "cloudfront_log_bucket" {
     }, {
     type        = "CanonicalUser"
     permissions = ["FULL_CONTROL"]
-    id          = "c4c1ede66af53448b93c283ce9448c4ba468c9432aa01d700d3878632f77d2d0"
-    # Ref. https://github.com/terraform-providers/terraform-provider-aws/issues/12512
+    id          = data.aws_cloudfront_log_delivery_canonical_user_id.cloudfront.id
     # Ref. https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/AccessLogs.html
   }]
   force_destroy = true

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.13.1"
 
   required_providers {
     aws    = ">= 3.60"

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.31"
+  required_version = ">= 0.13"
 
   required_providers {
     aws    = ">= 3.60"

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.31"
 
   required_providers {
-    aws    = ">= 3.50"
+    aws    = ">= 3.60"
     random = ">= 2.0"
   }
 }

--- a/examples/notification/README.md
+++ b/examples/notification/README.md
@@ -19,7 +19,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.50 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |

--- a/examples/notification/README.md
+++ b/examples/notification/README.md
@@ -19,7 +19,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.50 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |

--- a/examples/notification/versions.tf
+++ b/examples/notification/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.13.1"
 
   required_providers {
     aws    = ">= 3.50"

--- a/examples/notification/versions.tf
+++ b/examples/notification/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.31"
+  required_version = ">= 0.13"
 
   required_providers {
     aws    = ">= 3.50"

--- a/examples/object/README.md
+++ b/examples/object/README.md
@@ -19,7 +19,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.50 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 

--- a/examples/object/versions.tf
+++ b/examples/object/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.13.1"
 
   required_providers {
     aws    = ">= 3.50"

--- a/examples/s3-replication/README.md
+++ b/examples/s3-replication/README.md
@@ -21,7 +21,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.31 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.50 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 

--- a/examples/s3-replication/README.md
+++ b/examples/s3-replication/README.md
@@ -21,7 +21,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.50 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 

--- a/examples/s3-replication/versions.tf
+++ b/examples/s3-replication/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.13.1"
 
   required_providers {
     aws    = ">= 3.50"

--- a/examples/s3-replication/versions.tf
+++ b/examples/s3-replication/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.31"
+  required_version = ">= 0.13"
 
   required_providers {
     aws    = ">= 3.50"

--- a/modules/notification/README.md
+++ b/modules/notification/README.md
@@ -7,7 +7,7 @@ Creates S3 bucket notification resource with all supported types of deliveries: 
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.28 |
 
 ## Providers

--- a/modules/notification/README.md
+++ b/modules/notification/README.md
@@ -7,7 +7,7 @@ Creates S3 bucket notification resource with all supported types of deliveries: 
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.12.6 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.28 |
 
 ## Providers

--- a/modules/notification/versions.tf
+++ b/modules/notification/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.13.1"
 
   required_providers {
     aws = ">= 3.28"

--- a/modules/notification/versions.tf
+++ b/modules/notification/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.6"
+  required_version = ">= 0.13"
 
   required_providers {
     aws = ">= 3.28"

--- a/modules/object/README.md
+++ b/modules/object/README.md
@@ -7,7 +7,7 @@ Creates S3 bucket objects with different configurations.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.36 |
 
 ## Providers

--- a/modules/object/versions.tf
+++ b/modules/object/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.13.1"
 
   required_providers {
     aws = ">= 3.36"

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.12.31"
+  required_version = ">= 0.13"
 
   required_providers {
     aws = ">= 3.50"

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.13.1"
 
   required_providers {
     aws = ">= 3.50"

--- a/wrappers/notification/versions.tf
+++ b/wrappers/notification/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.13.1"
 }

--- a/wrappers/object/versions.tf
+++ b/wrappers/object/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.13.1"
 }

--- a/wrappers/versions.tf
+++ b/wrappers/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.13.1"
 }


### PR DESCRIPTION
## Description
Uses the new data resource for aws_cloudfront_log_delivery_canonical_user_id that provides this field instead of using the hardcoded value.

## Motivation and Context
Per this github issue: https://github.com/hashicorp/terraform-provider-aws/issues/12512 which has now been solved we can use this resource to provide this ID.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? --> Will need to update provider to v3.6
<!-- If so, please provide an explanation why it is necessary. --> The most recent provider has this data block

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I created this on my local by running terraform plan and apply and destroy to create the new bucket which was successfully created in AWS. To test cloudfront I have used this fork and have successfully received logs in s3.
