### PR TITLE
feat: Added Replication Time Control for Bucket Replication

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,8 +16,8 @@ repos:
 #        entry: /Users/Bob/Sites/terraform-aws-modules/scripts/generate-terraform-wrappers.sh --module-dir modules/notification --overwrite
 #        language: system
 #        pass_filenames: false
-  - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.50.0
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.55.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -37,7 +37,7 @@ repos:
           - '--args=--only=terraform_required_providers'
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
-  - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.0.1
     hooks:
       - id: check-merge-conflict

--- a/README.md
+++ b/README.md
@@ -181,3 +181,13 @@ No modules.
 | <a name="output_s3_bucket_region"></a> [s3\_bucket\_region](#output\_s3\_bucket\_region) | The AWS region this bucket resides in. |
 | <a name="output_s3_bucket_website_domain"></a> [s3\_bucket\_website\_domain](#output\_s3\_bucket\_website\_domain) | The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records. |
 | <a name="output_s3_bucket_website_endpoint"></a> [s3\_bucket\_website\_endpoint](#output\_s3\_bucket\_website\_endpoint) | The website endpoint, if the bucket is configured with a website. If not, this will be an empty string. |
+
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+## Authors
+
+Module is maintained by [Anton Babenko](https://github.com/antonbabenko) with help from [these awesome contributors](https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/graphs/contributors).
+
+## License
+
+Apache 2 Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/tree/master/LICENSE) for full details.

--- a/README.md
+++ b/README.md
@@ -1,120 +1,15 @@
-# AWS S3 bucket Terraform module
-
-Terraform module which creates S3 bucket on AWS with all (or almost all) features provided by Terraform AWS provider.
-
-These features of S3 bucket configurations are supported:
-
-- static web-site hosting
-- access logging
-- versioning
-- CORS
-- lifecycle rules
-- server-side encryption
-- object locking
-- Cross-Region Replication (CRR)
-- ELB log delivery bucket policy
-- ALB/NLB log delivery bucket policy
-
-## Usage
-
-### Private bucket with versioning enabled
-
-```hcl
-module "s3_bucket" {
-  source = "terraform-aws-modules/s3-bucket/aws"
-
-  bucket = "my-s3-bucket"
-  acl    = "private"
-
-  versioning = {
-    enabled = true
-  }
-
-}
-```
-
-### Bucket with ELB access log delivery policy attached
-
-```hcl
-module "s3_bucket_for_logs" {
-  source = "terraform-aws-modules/s3-bucket/aws"
-
-  bucket = "my-s3-bucket-for-logs"
-  acl    = "log-delivery-write"
-
-  # Allow deletion of non-empty bucket
-  force_destroy = true
-
-  attach_elb_log_delivery_policy = true
-}
-```
-
-### Bucket with ALB/NLB access log delivery policy attached
-
-```hcl
-module "s3_bucket_for_logs" {
-  source = "terraform-aws-modules/s3-bucket/aws"
-
-  bucket = "my-s3-bucket-for-logs"
-  acl    = "log-delivery-write"
-
-  # Allow deletion of non-empty bucket
-  force_destroy = true
-
-  attach_elb_log_delivery_policy = true  # Required for ALB logs
-  attach_lb_log_delivery_policy  = true  # Required for ALB/NLB logs
-}
-```
-
-## Conditional creation
-
-Sometimes you need to have a way to create S3 resources conditionally but Terraform does not allow to use `count` inside `module` block, so the solution is to specify argument `create_bucket`.
-
-```hcl
-# This S3 bucket will not be created
-module "s3_bucket" {
-  source = "terraform-aws-modules/s3-bucket/aws"
-
-  create_bucket = false
-  # ... omitted
-}
-```
-
-## Terragrunt and `variable "..." { type = any }`
-
-There is a bug [#1211](https://github.com/gruntwork-io/terragrunt/issues/1211) in Terragrunt related to the way how the variables of type `any` are passed to Terraform.
-
-This module solves this issue by supporting `jsonencode()`-string in addition to the expected type (`list` or `map`).
-
-In `terragrunt.hcl` you can write:
-
-```terraform
-inputs = {
-  bucket    = "foobar"            # `bucket` has type `string`, no need to jsonencode()
-  cors_rule = jsonencode([...])   # `cors_rule` has type `any`, so `jsonencode()` is required
-}
-```
-
-## Examples:
-
-- [Complete](https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/tree/master/examples/complete) - Complete S3 bucket with most of supported features enabled
-- [Cross-Region Replication](https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/tree/master/examples/s3-replication) - S3 bucket with Cross-Region Replication (CRR) enabled
-- [S3 Bucket Notifications](https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/tree/master/examples/notification) - S3 bucket notifications to Lambda functions, SQS queues, and SNS topics.
-- [S3 Bucket Object](https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/tree/master/examples/object) - Manage S3 bucket objects.
-
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.50 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.64 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.50 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.64 |
 
 ## Modules
 
@@ -180,12 +75,3 @@ No modules.
 | <a name="output_s3_bucket_region"></a> [s3\_bucket\_region](#output\_s3\_bucket\_region) | The AWS region this bucket resides in. |
 | <a name="output_s3_bucket_website_domain"></a> [s3\_bucket\_website\_domain](#output\_s3\_bucket\_website\_domain) | The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records. |
 | <a name="output_s3_bucket_website_endpoint"></a> [s3\_bucket\_website\_endpoint](#output\_s3\_bucket\_website\_endpoint) | The website endpoint, if the bucket is configured with a website. If not, this will be an empty string. |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-
-## Authors
-
-Module is maintained by [Anton Babenko](https://github.com/antonbabenko) with help from [these awesome contributors](https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/graphs/contributors).
-
-## License
-
-Apache 2 Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/tree/master/LICENSE) for full details.

--- a/README.md
+++ b/README.md
@@ -103,7 +103,6 @@ inputs = {
 - [S3 Bucket Object](https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/tree/master/examples/object) - Manage S3 bucket objects.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-
 ## Requirements
 
 | Name | Version |
@@ -181,7 +180,6 @@ No modules.
 | <a name="output_s3_bucket_region"></a> [s3\_bucket\_region](#output\_s3\_bucket\_region) | The AWS region this bucket resides in. |
 | <a name="output_s3_bucket_website_domain"></a> [s3\_bucket\_website\_domain](#output\_s3\_bucket\_website\_domain) | The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records. |
 | <a name="output_s3_bucket_website_endpoint"></a> [s3\_bucket\_website\_endpoint](#output\_s3\_bucket\_website\_endpoint) | The website endpoint, if the bucket is configured with a website. If not, this will be an empty string. |
-
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.64 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.64.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.64 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.64.0 |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,121 @@
+# AWS S3 bucket Terraform module
+
+Terraform module which creates S3 bucket on AWS with all (or almost all) features provided by Terraform AWS provider.
+
+These features of S3 bucket configurations are supported:
+
+- static web-site hosting
+- access logging
+- versioning
+- CORS
+- lifecycle rules
+- server-side encryption
+- object locking
+- Cross-Region Replication (CRR)
+- ELB log delivery bucket policy
+- ALB/NLB log delivery bucket policy
+
+## Usage
+
+### Private bucket with versioning enabled
+
+```hcl
+module "s3_bucket" {
+  source = "terraform-aws-modules/s3-bucket/aws"
+
+  bucket = "my-s3-bucket"
+  acl    = "private"
+
+  versioning = {
+    enabled = true
+  }
+
+}
+```
+
+### Bucket with ELB access log delivery policy attached
+
+```hcl
+module "s3_bucket_for_logs" {
+  source = "terraform-aws-modules/s3-bucket/aws"
+
+  bucket = "my-s3-bucket-for-logs"
+  acl    = "log-delivery-write"
+
+  # Allow deletion of non-empty bucket
+  force_destroy = true
+
+  attach_elb_log_delivery_policy = true
+}
+```
+
+### Bucket with ALB/NLB access log delivery policy attached
+
+```hcl
+module "s3_bucket_for_logs" {
+  source = "terraform-aws-modules/s3-bucket/aws"
+
+  bucket = "my-s3-bucket-for-logs"
+  acl    = "log-delivery-write"
+
+  # Allow deletion of non-empty bucket
+  force_destroy = true
+
+  attach_elb_log_delivery_policy = true  # Required for ALB logs
+  attach_lb_log_delivery_policy  = true  # Required for ALB/NLB logs
+}
+```
+
+## Conditional creation
+
+Sometimes you need to have a way to create S3 resources conditionally but Terraform does not allow to use `count` inside `module` block, so the solution is to specify argument `create_bucket`.
+
+```hcl
+# This S3 bucket will not be created
+module "s3_bucket" {
+  source = "terraform-aws-modules/s3-bucket/aws"
+
+  create_bucket = false
+  # ... omitted
+}
+```
+
+## Terragrunt and `variable "..." { type = any }`
+
+There is a bug [#1211](https://github.com/gruntwork-io/terragrunt/issues/1211) in Terragrunt related to the way how the variables of type `any` are passed to Terraform.
+
+This module solves this issue by supporting `jsonencode()`-string in addition to the expected type (`list` or `map`).
+
+In `terragrunt.hcl` you can write:
+
+```terraform
+inputs = {
+  bucket    = "foobar"            # `bucket` has type `string`, no need to jsonencode()
+  cors_rule = jsonencode([...])   # `cors_rule` has type `any`, so `jsonencode()` is required
+}
+```
+
+## Examples:
+
+- [Complete](https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/tree/master/examples/complete) - Complete S3 bucket with most of supported features enabled
+- [Cross-Region Replication](https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/tree/master/examples/s3-replication) - S3 bucket with Cross-Region Replication (CRR) enabled
+- [S3 Bucket Notifications](https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/tree/master/examples/notification) - S3 bucket notifications to Lambda functions, SQS queues, and SNS topics.
+- [S3 Bucket Object](https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/tree/master/examples/object) - Manage S3 bucket objects.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
 ## Requirements
 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.64.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.64 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.64.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.64 |
 
 ## Modules
 

--- a/examples/s3-replication/README.md
+++ b/examples/s3-replication/README.md
@@ -22,7 +22,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.50 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.64 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers

--- a/examples/s3-replication/README.md
+++ b/examples/s3-replication/README.md
@@ -29,16 +29,16 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.50 |
-| <a name="provider_aws.replica"></a> [aws.replica](#provider\_aws.replica) | >= 3.50 |
-| <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.64.1 |
+| <a name="provider_aws.replica"></a> [aws.replica](#provider\_aws.replica) | 3.64.1 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.1.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_replica_bucket"></a> [replica\_bucket](#module\_replica\_bucket) | ../../ |  |
-| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | ../../ |  |
+| <a name="module_replica_bucket"></a> [replica\_bucket](#module\_replica\_bucket) | ../../ | n/a |
+| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | ../../ | n/a |
 
 ## Resources
 

--- a/examples/s3-replication/README.md
+++ b/examples/s3-replication/README.md
@@ -29,16 +29,16 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 3.64.1 |
-| <a name="provider_aws.replica"></a> [aws.replica](#provider\_aws.replica) | 3.64.1 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.1.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.64 |
+| <a name="provider_aws.replica"></a> [aws.replica](#provider\_aws.replica) | >= 3.64 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_replica_bucket"></a> [replica\_bucket](#module\_replica\_bucket) | ../../ | n/a |
-| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | ../../ | n/a |
+| <a name="module_replica_bucket"></a> [replica\_bucket](#module\_replica\_bucket) | ../../ |  |
+| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | ../../ |  |
 
 ## Resources
 

--- a/examples/s3-replication/main.tf
+++ b/examples/s3-replication/main.tf
@@ -84,11 +84,11 @@ module "s3_bucket" {
             owner = "Destination"
           }
           replication_time = {
-            status = "Enabled"
+            status  = "Enabled"
             minutes = 15
           }
           metrics = {
-            status = "Enabled"
+            status  = "Enabled"
             minutes = 15
           }
         }

--- a/examples/s3-replication/main.tf
+++ b/examples/s3-replication/main.tf
@@ -83,6 +83,14 @@ module "s3_bucket" {
           access_control_translation = {
             owner = "Destination"
           }
+          replication_time = {
+            status = "Enabled"
+            minutes = 15
+          }
+          metrics = {
+            status = "Enabled"
+            minutes = 15
+          }
         }
       },
       {

--- a/examples/s3-replication/versions.tf
+++ b/examples/s3-replication/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.13.1"
 
   required_providers {
-    aws    = ">= 3.50"
+    aws    = ">= 3.64"
     random = ">= 2.0"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -159,7 +159,7 @@ resource "aws_s3_bucket" "this" {
                 for_each = length(keys(lookup(destination.value, "replication_time", {}))) == 0 ? [] : [lookup(destination.value, "replication_time", {})]
 
                 content {
-                  status = replication_time.value.status
+                  status  = replication_time.value.status
                   minutes = replication_time.value.minutes
                 }
               }
@@ -167,7 +167,7 @@ resource "aws_s3_bucket" "this" {
                 for_each = length(keys(lookup(destination.value, "metrics", {}))) == 0 ? [] : [lookup(destination.value, "metrics", {})]
 
                 content {
-                  status = metrics.value.status
+                  status  = metrics.value.status
                   minutes = metrics.value.minutes
                 }
               }

--- a/main.tf
+++ b/main.tf
@@ -163,6 +163,7 @@ resource "aws_s3_bucket" "this" {
                   minutes = replication_time.value.minutes
                 }
               }
+
               dynamic "metrics" {
                 for_each = length(keys(lookup(destination.value, "metrics", {}))) == 0 ? [] : [lookup(destination.value, "metrics", {})]
 

--- a/main.tf
+++ b/main.tf
@@ -154,6 +154,23 @@ resource "aws_s3_bucket" "this" {
                   owner = access_control_translation.value.owner
                 }
               }
+
+              dynamic "replication_time" {
+                for_each = length(keys(lookup(destination.value, "replication_time", {}))) == 0 ? [] : [lookup(destination.value, "replication_time", {})]
+
+                content {
+                  status = replication_time.value.status
+                  minutes = replication_time.value.minutes
+                }
+              }
+              dynamic "metrics" {
+                for_each = length(keys(lookup(destination.value, "metrics", {}))) == 0 ? [] : [lookup(destination.value, "metrics", {})]
+
+                content {
+                  status = metrics.value.status
+                  minutes = metrics.value.minutes
+                }
+              }
             }
           }
 

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.13.1"
 
   required_providers {
-    aws = ">= 3.64.0"
+    aws = ">= 3.64"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.13.1"
 
   required_providers {
-    aws = ">= 3.50"
+    aws = ">= 3.64"
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,6 @@ terraform {
   required_version = ">= 0.13.1"
 
   required_providers {
-    aws = ">= 3.64"
+    aws = ">= 3.64.0"
   }
 }

--- a/wrappers/README.md
+++ b/wrappers/README.md
@@ -28,7 +28,7 @@ inputs = {
 }
 ```
 
-## Usage with Terraform:
+## Usage with Terraform
 
 ```hcl
 module "wrapper" {

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -30,4 +30,6 @@ module "wrapper" {
   block_public_policy                   = lookup(each.value, "block_public_policy", false)
   ignore_public_acls                    = lookup(each.value, "ignore_public_acls", false)
   restrict_public_buckets               = lookup(each.value, "restrict_public_buckets", false)
+  control_object_ownership              = lookup(each.value, "control_object_ownership", false)
+  object_ownership                      = lookup(each.value, "object_ownership", "ObjectWriter")
 }

--- a/wrappers/notification/README.md
+++ b/wrappers/notification/README.md
@@ -6,7 +6,7 @@ You may want to use a single Terragrunt configuration file to manage multiple re
 
 This wrapper does not implement any extra functionality.
 
-# Usage with Terragrunt
+## Usage with Terragrunt
 
 `terragrunt.hcl`:
 
@@ -28,7 +28,7 @@ inputs = {
 }
 ```
 
-## Usage with Terraform:
+## Usage with Terraform
 
 ```hcl
 module "wrapper" {

--- a/wrappers/object/README.md
+++ b/wrappers/object/README.md
@@ -6,7 +6,7 @@ You may want to use a single Terragrunt configuration file to manage multiple re
 
 This wrapper does not implement any extra functionality.
 
-# Usage with Terragrunt
+## Usage with Terragrunt
 
 `terragrunt.hcl`:
 
@@ -28,7 +28,7 @@ inputs = {
 }
 ```
 
-## Usage with Terraform:
+## Usage with Terraform
 
 ```hcl
 module "wrapper" {


### PR DESCRIPTION
## Description
This change is about taking into account the recent enhancement of the AWS Terraform Provider which now allows to set S3 Replication Time Control (RTC)

## Motivation and Context
Thanks to this enhancement, we will be able to provision S3 Bucket Replication Configurations with SLAs and Metrics on the Replication itself from this terraform module.
It's the reflection on the module of the closure of the following issue : https://github.com/hashicorp/terraform-provider-aws/issues/10974

## Breaking Changes
There is no breaking change since I have just added the right attributes on the Replication configuration which are read from user input in the destination block of the replication_configuration attribute.

## How Has This Been Tested?
- [X ] I have tested and validated these changes using one or more of the provided `examples/*` projects

I have adapted the s3-replication example by adding the right input and I was able to successfully see metrics on the AWS S3 Bucket Console.

There was no need to add any control over user input since AWS API provides meaningful error messages in case user input is wrong :

│ Error: expected replication_configuration.0.rules.0.destination.0.replication_time.0.minutes to be in the range (15 - 15), got 16
│
│   with module.s3_bucket.aws_s3_bucket.this[0],
│   on ../../main.tf line 5, in resource "aws_s3_bucket" "this":
│    5: resource "aws_s3_bucket" "this" {
│

│ Error: expected replication_configuration.0.rules.0.destination.0.replication_time.0.status to be one of [Enabled Disabled], got yes
│
│   with module.s3_bucket.aws_s3_bucket.this[0],
│   on ../../main.tf line 5, in resource "aws_s3_bucket" "this":
│    5: resource "aws_s3_bucket" "this" {
│

│ Error: expected replication_configuration.0.rules.0.destination.0.metrics.0.minutes to be in the range (10 - 15), got 16
│
│   with module.s3_bucket.aws_s3_bucket.this[0],
│   on ../../main.tf line 5, in resource "aws_s3_bucket" "this":
│    5: resource "aws_s3_bucket" "this" {
│

│ Error: expected replication_configuration.0.rules.0.destination.0.metrics.0.status to be one of [Enabled Disabled], got true
│
│   with module.s3_bucket.aws_s3_bucket.this[0],
│   on ../../main.tf line 5, in resource "aws_s3_bucket" "this":
│    5: resource "aws_s3_bucket" "this" {
│

In this case the module users, will be easily able to correct their input to feed with the right values.

I have also ran pre-commit hooks as per the original pre-commit config file.

Thanks again for your review and feedback.

Bests.