### PR TITLE
chore: Update CI workflow to use composite actions and update pre-commit versions

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -2,98 +2,77 @@ name: Pre-Commit
 
 on:
   pull_request:
-  push:
     branches:
+      - main
       - master
 
+env:
+  TERRAFORM_DOCS_VERSION: v0.16.0
+
 jobs:
-  # Min Terraform version(s)
-  getDirectories:
-    name: Get root directories
+  collectInputs:
+    name: Collect workflow inputs
     runs-on: ubuntu-latest
+    outputs:
+      directories: ${{ steps.dirs.outputs.directories }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Install Python
-        uses: actions/setup-python@v2
-      - name: Build matrix
-        id: matrix
-        run: |
-          DIRS=$(python -c "import json; import glob; print(json.dumps([x.replace('/versions.tf', '') for x in glob.glob('./**/versions.tf', recursive=True)]))")
-          echo "::set-output name=directories::$DIRS"
-    outputs:
-      directories: ${{ steps.matrix.outputs.directories }}
+
+      - name: Get root directories
+        id: dirs
+        uses: clowdhaus/terraform-composite-actions/directories@v1.3.0
 
   preCommitMinVersions:
-    name: Min TF validate
-    needs: getDirectories
+    name: Min TF pre-commit
+    needs: collectInputs
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        directory: ${{ fromJson(needs.getDirectories.outputs.directories) }}
+        directory: ${{ fromJson(needs.collectInputs.outputs.directories) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Install Python
-        uses: actions/setup-python@v2
+
       - name: Terraform min/max versions
         id: minMax
-        uses: clowdhaus/terraform-min-max@v1.0.2
+        uses: clowdhaus/terraform-min-max@v1.0.3
         with:
           directory: ${{ matrix.directory }}
-      - name: Install Terraform v${{ steps.minMax.outputs.minVersion }}
-        uses: hashicorp/setup-terraform@v1
-        with:
-          terraform_version: ${{ steps.minMax.outputs.minVersion }}
-      - name: Install pre-commit dependencies
-        run: pip install pre-commit
-      - name: Execute pre-commit
+
+      - name: Pre-commit Terraform ${{ steps.minMax.outputs.minVersion }}
         # Run only validate pre-commit check on min version supported
         if: ${{ matrix.directory !=  '.' }}
-        run: pre-commit run terraform_validate --color=always --show-diff-on-failure --files ${{ matrix.directory }}/*
-      - name: Execute pre-commit
+        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.3.0
+        with:
+          terraform-version: ${{ steps.minMax.outputs.minVersion }}
+          args: 'terraform_validate --color=always --show-diff-on-failure --files ${{ matrix.directory }}/*'
+
+      - name: Pre-commit Terraform ${{ steps.minMax.outputs.minVersion }}
         # Run only validate pre-commit check on min version supported
         if: ${{ matrix.directory ==  '.' }}
-        run: pre-commit run terraform_validate --color=always --show-diff-on-failure --files $(ls *.tf)
-
-  # Max Terraform version
-  getBaseVersion:
-    name: Module max TF version
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Terraform min/max versions
-        id: minMax
-        uses: clowdhaus/terraform-min-max@v1.0.2
-    outputs:
-      minVersion: ${{ steps.minMax.outputs.minVersion }}
-      maxVersion: ${{ steps.minMax.outputs.maxVersion }}
+        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.3.0
+        with:
+          terraform-version: ${{ steps.minMax.outputs.minVersion }}
+          args: 'terraform_validate --color=always --show-diff-on-failure --files $(ls *.tf)'
 
   preCommitMaxVersion:
     name: Max TF pre-commit
     runs-on: ubuntu-latest
-    needs: getBaseVersion
-    strategy:
-      fail-fast: false
-      matrix:
-        version:
-          - ${{ needs.getBaseVersion.outputs.maxVersion }}
+    needs: collectInputs
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Install Python
-        uses: actions/setup-python@v2
-      - name: Install Terraform v${{ matrix.version }}
-        uses: hashicorp/setup-terraform@v1
         with:
-          terraform_version: ${{ matrix.version }}
-      - name: Install pre-commit dependencies
-        run: |
-          pip install pre-commit
-          curl -Lo ./terraform-docs.tar.gz https://github.com/terraform-docs/terraform-docs/releases/download/v0.13.0/terraform-docs-v0.13.0-$(uname)-amd64.tar.gz && tar -xzf terraform-docs.tar.gz && chmod +x terraform-docs && sudo mv terraform-docs /usr/bin/
-          curl -L "$(curl -s https://api.github.com/repos/terraform-linters/tflint/releases/latest | grep -o -E "https://.+?_linux_amd64.zip")" > tflint.zip && unzip tflint.zip && rm tflint.zip && sudo mv tflint /usr/bin/
-      - name: Execute pre-commit
-        # Run all pre-commit checks on max version supported
-        if: ${{ matrix.version ==  needs.getBaseVersion.outputs.maxVersion }}
-        run: pre-commit run --color=always --show-diff-on-failure --all-files
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+
+      - name: Terraform min/max versions
+        id: minMax
+        uses: clowdhaus/terraform-min-max@v1.0.3
+
+      - name: Pre-commit Terraform ${{ steps.minMax.outputs.maxVersion }}
+        uses: clowdhaus/terraform-composite-actions/pre-commit@v1.3.0
+        with:
+          terraform-version: ${{ steps.minMax.outputs.maxVersion }}
+          terraform-docs-version: ${{ env.TERRAFORM_DOCS_VERSION }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,12 +16,14 @@ repos:
 #        entry: /Users/Bob/Sites/terraform-aws-modules/scripts/generate-terraform-wrappers.sh --module-dir modules/notification --overwrite
 #        language: system
 #        pass_filenames: false
-  - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.50.0
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.55.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
       - id: terraform_docs
+        args:
+          - '--args=--lockfile=false'
       - id: terraform_tflint
         args:
           - '--args=--only=terraform_deprecated_interpolation'
@@ -37,7 +39,7 @@ repos:
           - '--args=--only=terraform_required_providers'
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
-  - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.0.1
     hooks:
       - id: check-merge-conflict

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,12 @@
 .PHONY: changelog release
 
+scope ?= "minor"
+
+changelog-unrelease:
+	git-chglog --no-case -o CHANGELOG.md
+
 changelog:
-	git-chglog -o CHANGELOG.md --next-tag `semtag final -s minor -o`
+	git-chglog --no-case -o CHANGELOG.md --next-tag `semtag final -s $(scope) -o -f`
 
 release:
-	semtag final -s minor
+	semtag final -s $(scope)

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -44,9 +44,9 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_cloudfront_log_bucket"></a> [cloudfront\_log\_bucket](#module\_cloudfront\_log\_bucket) | ../../ |  |
-| <a name="module_log_bucket"></a> [log\_bucket](#module\_log\_bucket) | ../../ |  |
-| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | ../../ |  |
+| <a name="module_cloudfront_log_bucket"></a> [cloudfront\_log\_bucket](#module\_cloudfront\_log\_bucket) | ../../ | n/a |
+| <a name="module_log_bucket"></a> [log\_bucket](#module\_log\_bucket) | ../../ | n/a |
+| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | ../../ | n/a |
 
 ## Resources
 

--- a/examples/notification/README.md
+++ b/examples/notification/README.md
@@ -36,10 +36,10 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_all_notifications"></a> [all\_notifications](#module\_all\_notifications) | ../../modules/notification |  |
+| <a name="module_all_notifications"></a> [all\_notifications](#module\_all\_notifications) | ../../modules/notification | n/a |
 | <a name="module_lambda_function1"></a> [lambda\_function1](#module\_lambda\_function1) | terraform-aws-modules/lambda/aws | ~> 2.0 |
 | <a name="module_lambda_function2"></a> [lambda\_function2](#module\_lambda\_function2) | terraform-aws-modules/lambda/aws | ~> 2.0 |
-| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | ../../ |  |
+| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | ../../ | n/a |
 | <a name="module_sns_topic1"></a> [sns\_topic1](#module\_sns\_topic1) | terraform-aws-modules/sns/aws | ~> 3.0 |
 | <a name="module_sns_topic2"></a> [sns\_topic2](#module\_sns\_topic2) | terraform-aws-modules/sns/aws | ~> 3.0 |
 

--- a/examples/object/README.md
+++ b/examples/object/README.md
@@ -34,11 +34,11 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_object"></a> [object](#module\_object) | ../../modules/object |  |
-| <a name="module_object_complete"></a> [object\_complete](#module\_object\_complete) | ../../modules/object |  |
-| <a name="module_object_locked"></a> [object\_locked](#module\_object\_locked) | ../../modules/object |  |
-| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | ../../ |  |
-| <a name="module_s3_bucket_with_object_lock"></a> [s3\_bucket\_with\_object\_lock](#module\_s3\_bucket\_with\_object\_lock) | ../../ |  |
+| <a name="module_object"></a> [object](#module\_object) | ../../modules/object | n/a |
+| <a name="module_object_complete"></a> [object\_complete](#module\_object\_complete) | ../../modules/object | n/a |
+| <a name="module_object_locked"></a> [object\_locked](#module\_object\_locked) | ../../modules/object | n/a |
+| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | ../../ | n/a |
+| <a name="module_s3_bucket_with_object_lock"></a> [s3\_bucket\_with\_object\_lock](#module\_s3\_bucket\_with\_object\_lock) | ../../ | n/a |
 
 ## Resources
 

--- a/examples/s3-replication/README.md
+++ b/examples/s3-replication/README.md
@@ -37,8 +37,8 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_replica_bucket"></a> [replica\_bucket](#module\_replica\_bucket) | ../../ |  |
-| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | ../../ |  |
+| <a name="module_replica_bucket"></a> [replica\_bucket](#module\_replica\_bucket) | ../../ | n/a |
+| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | ../../ | n/a |
 
 ## Resources
 


### PR DESCRIPTION
## Description
- update CI workflow to use composite actions
- update pre-commit versions to latest
- update terraform-docs to latest version v0.16.0
- add new argument to `terraform_docs` hook which avoids pinning to exact version due to conflict of .terraform.lock.hcl file (https://github.com/terraform-docs/terraform-docs/pull/527)
- update Makefile to allow for breaking changes (scope) and rolling back a release

## Motivation and Context
- consolidates CI actions and updates terraform-docs to latest

## Breaking Changes
- no

## How Has This Been Tested?
- documentation and CI change only, no module changes
