### PR TITLE
feat: Added optional bucket policy for requiring TLS 1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ No modules.
 | [aws_iam_policy_document.deny_insecure_transport](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.elb_log_delivery](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.lb_log_delivery](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.require_latest_tls](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 
@@ -145,6 +146,7 @@ No modules.
 | <a name="input_attach_lb_log_delivery_policy"></a> [attach\_lb\_log\_delivery\_policy](#input\_attach\_lb\_log\_delivery\_policy) | Controls if S3 bucket should have ALB/NLB log delivery policy attached | `bool` | `false` | no |
 | <a name="input_attach_policy"></a> [attach\_policy](#input\_attach\_policy) | Controls if S3 bucket should have bucket policy attached (set to `true` to use value of `policy` as bucket policy) | `bool` | `false` | no |
 | <a name="input_attach_public_policy"></a> [attach\_public\_policy](#input\_attach\_public\_policy) | Controls if a user defined public bucket policy will be attached (set to `false` to allow upstream to apply defaults to the bucket) | `bool` | `true` | no |
+| <a name="input_attach_require_latest_tls_policy"></a> [attach\_require\_latest\_tls\_policy](#input\_attach\_require\_latest\_tls\_policy) | Controls if S3 bucket should require the latest version of TLS | `bool` | `false` | no |
 | <a name="input_block_public_acls"></a> [block\_public\_acls](#input\_block\_public\_acls) | Whether Amazon S3 should block public ACLs for this bucket. | `bool` | `false` | no |
 | <a name="input_block_public_policy"></a> [block\_public\_policy](#input\_block\_public\_policy) | Whether Amazon S3 should block public bucket policies for this bucket. | `bool` | `false` | no |
 | <a name="input_bucket"></a> [bucket](#input\_bucket) | (Optional, Forces new resource) The name of the bucket. If omitted, Terraform will assign a random, unique name. | `string` | `null` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -2,11 +2,6 @@ locals {
   bucket_name = "s3-bucket-${random_pet.this.id}"
 }
 
-provider "aws" {
-  region  = "us-east-2"
-  profile = "merstab-terraform"
-}
-
 data "aws_canonical_user_id" "current" {}
 
 data "aws_cloudfront_log_delivery_canonical_user_id" "cloudfront" {}

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -2,6 +2,11 @@ locals {
   bucket_name = "s3-bucket-${random_pet.this.id}"
 }
 
+provider "aws" {
+  region  = "us-east-2"
+  profile = "merstab-terraform"
+}
+
 data "aws_canonical_user_id" "current" {}
 
 data "aws_cloudfront_log_delivery_canonical_user_id" "cloudfront" {}
@@ -59,6 +64,7 @@ module "log_bucket" {
   attach_elb_log_delivery_policy        = true
   attach_lb_log_delivery_policy         = true
   attach_deny_insecure_transport_policy = true
+  attach_require_latest_tls_policy      = true
 }
 
 module "cloudfront_log_bucket" {
@@ -90,6 +96,7 @@ module "s3_bucket" {
   policy        = data.aws_iam_policy_document.bucket_policy.json
 
   attach_deny_insecure_transport_policy = true
+  attach_require_latest_tls_policy      = true
 
   tags = {
     Owner = "Anton"

--- a/variables.tf
+++ b/variables.tf
@@ -22,6 +22,12 @@ variable "attach_deny_insecure_transport_policy" {
   default     = false
 }
 
+variable "attach_require_latest_tls_policy" {
+  description = "Controls if S3 bucket should require the latest version of TLS"
+  type        = bool
+  default     = false
+}
+
 variable "attach_policy" {
   description = "Controls if S3 bucket should have bucket policy attached (set to `true` to use value of `policy` as bucket policy)"
   type        = bool


### PR DESCRIPTION
## Description
This adds an additional parameter that toggles whether to add a bucket policy for requiring TLS 1.2 in order to access the bucket.

## Motivation and Context
I'm working in an organization that requires TLS v1.2 on all of their buckets. I was already using the module and thought this is a common enough need in secure organizations that we should generalize it. I created an issue requesting the feature here: https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/issues/125.

Fixes #125

## Breaking Changes
No

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
I tested using the `examples/complete` project by adding the new parameter on to the buckets. I confirmed in my console that the policy was created.
