### PR TITLE
feat: Add attach Cloudtrail log delivery policy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ These features of S3 bucket configurations are supported:
 - server-side encryption
 - object locking
 - Cross-Region Replication (CRR)
+- CloudTrail log delivery bucket policy
 - ELB log delivery bucket policy
 - ALB/NLB log delivery bucket policy
 
@@ -128,7 +129,9 @@ No modules.
 | [aws_s3_bucket_ownership_controls.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
 | [aws_s3_bucket_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_public_access_block.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_elb_service_account.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/elb_service_account) | data source |
+| [aws_iam_policy_document.cloudtrail_log_delivery](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.combined](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.deny_insecure_transport](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.elb_log_delivery](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -140,6 +143,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_acceleration_status"></a> [acceleration\_status](#input\_acceleration\_status) | (Optional) Sets the accelerate configuration of an existing bucket. Can be Enabled or Suspended. | `string` | `null` | no |
 | <a name="input_acl"></a> [acl](#input\_acl) | (Optional) The canned ACL to apply. Defaults to 'private'. Conflicts with `grant` | `string` | `"private"` | no |
+| <a name="input_attach_cloudtrail_log_delivery_policy"></a> [attach\_cloudtrail\_log\_delivery\_policy](#input\_attach\_cloudtrail\_log\_delivery\_policy) | Controls if S3 bucket should have CloudTrail log delivery policy attached | `bool` | `false` | no |
 | <a name="input_attach_deny_insecure_transport_policy"></a> [attach\_deny\_insecure\_transport\_policy](#input\_attach\_deny\_insecure\_transport\_policy) | Controls if S3 bucket should have deny non-SSL transport policy attached | `bool` | `false` | no |
 | <a name="input_attach_elb_log_delivery_policy"></a> [attach\_elb\_log\_delivery\_policy](#input\_attach\_elb\_log\_delivery\_policy) | Controls if S3 bucket should have ELB log delivery policy attached | `bool` | `false` | no |
 | <a name="input_attach_lb_log_delivery_policy"></a> [attach\_lb\_log\_delivery\_policy](#input\_attach\_lb\_log\_delivery\_policy) | Controls if S3 bucket should have ALB/NLB log delivery policy attached | `bool` | `false` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -56,6 +56,7 @@ module "log_bucket" {
   bucket                                = "logs-${random_pet.this.id}"
   acl                                   = "log-delivery-write"
   force_destroy                         = true
+  attach_cloudtrail_log_delivery_policy = true
   attach_elb_log_delivery_policy        = true
   attach_lb_log_delivery_policy         = true
   attach_deny_insecure_transport_policy = true

--- a/variables.tf
+++ b/variables.tf
@@ -16,6 +16,12 @@ variable "attach_lb_log_delivery_policy" {
   default     = false
 }
 
+variable "attach_cloudtrail_log_delivery_policy" {
+  description = "Controls if S3 bucket should have CloudTrail log delivery policy attached"
+  type        = bool
+  default     = false
+}
+
 variable "attach_deny_insecure_transport_policy" {
   description = "Controls if S3 bucket should have deny non-SSL transport policy attached"
   type        = bool

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -4,6 +4,7 @@ module "wrapper" {
   for_each = var.items
 
   create_bucket                         = lookup(each.value, "create_bucket", true)
+  attach_cloudtrail_log_delivery_policy = lookup(each.value, "attach_cloudtrail_log_delivery_policy", false)
   attach_elb_log_delivery_policy        = lookup(each.value, "attach_elb_log_delivery_policy", false)
   attach_lb_log_delivery_policy         = lookup(each.value, "attach_lb_log_delivery_policy", false)
   attach_deny_insecure_transport_policy = lookup(each.value, "attach_deny_insecure_transport_policy", false)


### PR DESCRIPTION
## Description
Allow to easily attach a simple policy to allow logs write from CloudTrail like described [here](https://docs.aws.amazon.com/awscloudtrail/latest/userguide/create-s3-bucket-policy-for-cloudtrail.html).

## Motivation and Context
See https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/issues/86

## Breaking Changes
No breaking changes.

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I use this in my Terraform projects
