### PR TITLE
Upgrade S3 module to support AWS Provider 4.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,13 +108,13 @@ inputs = {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.69 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.4 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 3.69 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.4 |
 
 ## Modules
 
@@ -125,9 +125,20 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_s3_bucket.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_accelerate_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_accelerate_configuration) | resource |
+| [aws_s3_bucket_acl.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) | resource |
+| [aws_s3_bucket_cors_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_cors_configuration) | resource |
+| [aws_s3_bucket_lifecycle_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
+| [aws_s3_bucket_logging.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_logging) | resource |
+| [aws_s3_bucket_object_lock_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_object_lock_configuration) | resource |
 | [aws_s3_bucket_ownership_controls.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
 | [aws_s3_bucket_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_public_access_block.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_s3_bucket_replication_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_replication_configuration) | resource |
+| [aws_s3_bucket_request_payment_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_request_payment_configuration) | resource |
+| [aws_s3_bucket_server_side_encryption_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
+| [aws_s3_bucket_versioning.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
+| [aws_s3_bucket_website_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_website_configuration) | resource |
 | [aws_elb_service_account.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/elb_service_account) | data source |
 | [aws_iam_policy_document.combined](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.deny_insecure_transport](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -140,6 +151,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_acceleration_status"></a> [acceleration\_status](#input\_acceleration\_status) | (Optional) Sets the accelerate configuration of an existing bucket. Can be Enabled or Suspended. | `string` | `null` | no |
+| <a name="input_access_control_policy"></a> [access\_control\_policy](#input\_access\_control\_policy) | An ACL policy grant. Conflicts with `acl` | `any` | `[]` | no |
 | <a name="input_acl"></a> [acl](#input\_acl) | (Optional) The canned ACL to apply. Defaults to 'private'. Conflicts with `grant` | `string` | `"private"` | no |
 | <a name="input_attach_deny_insecure_transport_policy"></a> [attach\_deny\_insecure\_transport\_policy](#input\_attach\_deny\_insecure\_transport\_policy) | Controls if S3 bucket should have deny non-SSL transport policy attached | `bool` | `false` | no |
 | <a name="input_attach_elb_log_delivery_policy"></a> [attach\_elb\_log\_delivery\_policy](#input\_attach\_elb\_log\_delivery\_policy) | Controls if S3 bucket should have ELB log delivery policy attached | `bool` | `false` | no |
@@ -155,7 +167,6 @@ No modules.
 | <a name="input_cors_rule"></a> [cors\_rule](#input\_cors\_rule) | List of maps containing rules for Cross-Origin Resource Sharing. | `any` | `[]` | no |
 | <a name="input_create_bucket"></a> [create\_bucket](#input\_create\_bucket) | Controls if S3 bucket should be created | `bool` | `true` | no |
 | <a name="input_force_destroy"></a> [force\_destroy](#input\_force\_destroy) | (Optional, Default:false ) A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable. | `bool` | `false` | no |
-| <a name="input_grant"></a> [grant](#input\_grant) | An ACL policy grant. Conflicts with `acl` | `any` | `[]` | no |
 | <a name="input_ignore_public_acls"></a> [ignore\_public\_acls](#input\_ignore\_public\_acls) | Whether Amazon S3 should ignore public ACLs for this bucket. | `bool` | `false` | no |
 | <a name="input_lifecycle_rule"></a> [lifecycle\_rule](#input\_lifecycle\_rule) | List of maps containing configuration of object lifecycle management. | `any` | `[]` | no |
 | <a name="input_logging"></a> [logging](#input\_logging) | Map containing access bucket logging configuration. | `map(string)` | `{}` | no |
@@ -168,7 +179,7 @@ No modules.
 | <a name="input_server_side_encryption_configuration"></a> [server\_side\_encryption\_configuration](#input\_server\_side\_encryption\_configuration) | Map containing server-side encryption configuration. | `any` | `{}` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A mapping of tags to assign to the bucket. | `map(string)` | `{}` | no |
 | <a name="input_versioning"></a> [versioning](#input\_versioning) | Map containing versioning configuration. | `map(string)` | `{}` | no |
-| <a name="input_website"></a> [website](#input\_website) | Map containing static web-site hosting or redirect configuration. | `map(string)` | `{}` | no |
+| <a name="input_website"></a> [website](#input\_website) | Map containing static web-site hosting or redirect configuration. | `map(any)` | `{}` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -8,258 +8,15 @@ resource "aws_s3_bucket" "this" {
   bucket        = var.bucket
   bucket_prefix = var.bucket_prefix
 
-  # hack when `null` value can't be used (eg, from terragrunt, https://github.com/gruntwork-io/terragrunt/pull/1367)
-  acl = var.acl != "null" ? var.acl : null
-
-  tags                = var.tags
-  force_destroy       = var.force_destroy
-  acceleration_status = var.acceleration_status
-  request_payer       = var.request_payer
-
-  dynamic "website" {
-    for_each = length(keys(var.website)) == 0 ? [] : [var.website]
-
-    content {
-      index_document           = lookup(website.value, "index_document", null)
-      error_document           = lookup(website.value, "error_document", null)
-      redirect_all_requests_to = lookup(website.value, "redirect_all_requests_to", null)
-      routing_rules            = lookup(website.value, "routing_rules", null)
-    }
-  }
-
-  dynamic "cors_rule" {
-    for_each = try(jsondecode(var.cors_rule), var.cors_rule)
-
-    content {
-      allowed_methods = cors_rule.value.allowed_methods
-      allowed_origins = cors_rule.value.allowed_origins
-      allowed_headers = lookup(cors_rule.value, "allowed_headers", null)
-      expose_headers  = lookup(cors_rule.value, "expose_headers", null)
-      max_age_seconds = lookup(cors_rule.value, "max_age_seconds", null)
-    }
-  }
-
-  dynamic "versioning" {
-    for_each = length(keys(var.versioning)) == 0 ? [] : [var.versioning]
-
-    content {
-      enabled    = lookup(versioning.value, "enabled", null)
-      mfa_delete = lookup(versioning.value, "mfa_delete", null)
-    }
-  }
-
-  dynamic "logging" {
-    for_each = length(keys(var.logging)) == 0 ? [] : [var.logging]
-
-    content {
-      target_bucket = logging.value.target_bucket
-      target_prefix = lookup(logging.value, "target_prefix", null)
-    }
-  }
-
-  dynamic "grant" {
-    for_each = try(jsondecode(var.grant), var.grant)
-
-    content {
-      id          = lookup(grant.value, "id", null)
-      type        = grant.value.type
-      permissions = grant.value.permissions
-      uri         = lookup(grant.value, "uri", null)
-    }
-  }
-
-  dynamic "lifecycle_rule" {
-    for_each = try(jsondecode(var.lifecycle_rule), var.lifecycle_rule)
-
-    content {
-      id                                     = lookup(lifecycle_rule.value, "id", null)
-      prefix                                 = lookup(lifecycle_rule.value, "prefix", null)
-      tags                                   = lookup(lifecycle_rule.value, "tags", null)
-      abort_incomplete_multipart_upload_days = lookup(lifecycle_rule.value, "abort_incomplete_multipart_upload_days", null)
-      enabled                                = lifecycle_rule.value.enabled
-
-      # Max 1 block - expiration
-      dynamic "expiration" {
-        for_each = length(keys(lookup(lifecycle_rule.value, "expiration", {}))) == 0 ? [] : [lookup(lifecycle_rule.value, "expiration", {})]
-
-        content {
-          date                         = lookup(expiration.value, "date", null)
-          days                         = lookup(expiration.value, "days", null)
-          expired_object_delete_marker = lookup(expiration.value, "expired_object_delete_marker", null)
-        }
-      }
-
-      # Several blocks - transition
-      dynamic "transition" {
-        for_each = lookup(lifecycle_rule.value, "transition", [])
-
-        content {
-          date          = lookup(transition.value, "date", null)
-          days          = lookup(transition.value, "days", null)
-          storage_class = transition.value.storage_class
-        }
-      }
-
-      # Max 1 block - noncurrent_version_expiration
-      dynamic "noncurrent_version_expiration" {
-        for_each = length(keys(lookup(lifecycle_rule.value, "noncurrent_version_expiration", {}))) == 0 ? [] : [lookup(lifecycle_rule.value, "noncurrent_version_expiration", {})]
-
-        content {
-          days = lookup(noncurrent_version_expiration.value, "days", null)
-        }
-      }
-
-      # Several blocks - noncurrent_version_transition
-      dynamic "noncurrent_version_transition" {
-        for_each = lookup(lifecycle_rule.value, "noncurrent_version_transition", [])
-
-        content {
-          days          = lookup(noncurrent_version_transition.value, "days", null)
-          storage_class = noncurrent_version_transition.value.storage_class
-        }
-      }
-    }
-  }
-
-  # Max 1 block - replication_configuration
-  dynamic "replication_configuration" {
-    for_each = length(keys(var.replication_configuration)) == 0 ? [] : [var.replication_configuration]
-
-    content {
-      role = replication_configuration.value.role
-
-      dynamic "rules" {
-        for_each = replication_configuration.value.rules
-
-        content {
-          id                               = lookup(rules.value, "id", null)
-          priority                         = lookup(rules.value, "priority", null)
-          prefix                           = lookup(rules.value, "prefix", null)
-          delete_marker_replication_status = lookup(rules.value, "delete_marker_replication_status", null)
-          status                           = rules.value.status
-
-          dynamic "destination" {
-            for_each = length(keys(lookup(rules.value, "destination", {}))) == 0 ? [] : [lookup(rules.value, "destination", {})]
-
-            content {
-              bucket             = destination.value.bucket
-              storage_class      = lookup(destination.value, "storage_class", null)
-              replica_kms_key_id = lookup(destination.value, "replica_kms_key_id", null)
-              account_id         = lookup(destination.value, "account_id", null)
-
-              dynamic "access_control_translation" {
-                for_each = length(keys(lookup(destination.value, "access_control_translation", {}))) == 0 ? [] : [lookup(destination.value, "access_control_translation", {})]
-
-                content {
-                  owner = access_control_translation.value.owner
-                }
-              }
-
-              dynamic "replication_time" {
-                for_each = length(keys(lookup(destination.value, "replication_time", {}))) == 0 ? [] : [lookup(destination.value, "replication_time", {})]
-
-                content {
-                  status  = replication_time.value.status
-                  minutes = replication_time.value.minutes
-                }
-              }
-
-              dynamic "metrics" {
-                for_each = length(keys(lookup(destination.value, "metrics", {}))) == 0 ? [] : [lookup(destination.value, "metrics", {})]
-
-                content {
-                  status  = metrics.value.status
-                  minutes = metrics.value.minutes
-                }
-              }
-            }
-          }
-
-          dynamic "source_selection_criteria" {
-            for_each = length(keys(lookup(rules.value, "source_selection_criteria", {}))) == 0 ? [] : [lookup(rules.value, "source_selection_criteria", {})]
-
-            content {
-
-              dynamic "sse_kms_encrypted_objects" {
-                for_each = length(keys(lookup(source_selection_criteria.value, "sse_kms_encrypted_objects", {}))) == 0 ? [] : [lookup(source_selection_criteria.value, "sse_kms_encrypted_objects", {})]
-
-                content {
-
-                  enabled = sse_kms_encrypted_objects.value.enabled
-                }
-              }
-            }
-          }
-
-          # Send empty map if `filter` is an empty map or absent entirely
-          dynamic "filter" {
-            for_each = length(keys(lookup(rules.value, "filter", {}))) == 0 ? [{}] : []
-
-            content {}
-          }
-
-          # Send `filter` if it is present and has at least one field
-          dynamic "filter" {
-            for_each = length(keys(lookup(rules.value, "filter", {}))) != 0 ? [lookup(rules.value, "filter", {})] : []
-
-            content {
-              prefix = lookup(filter.value, "prefix", null)
-              tags   = lookup(filter.value, "tags", null)
-            }
-          }
-
-        }
-      }
-    }
-  }
-
-  # Max 1 block - server_side_encryption_configuration
-  dynamic "server_side_encryption_configuration" {
-    for_each = length(keys(var.server_side_encryption_configuration)) == 0 ? [] : [var.server_side_encryption_configuration]
-
-    content {
-
-      dynamic "rule" {
-        for_each = length(keys(lookup(server_side_encryption_configuration.value, "rule", {}))) == 0 ? [] : [lookup(server_side_encryption_configuration.value, "rule", {})]
-
-        content {
-          bucket_key_enabled = lookup(rule.value, "bucket_key_enabled", null)
-
-          dynamic "apply_server_side_encryption_by_default" {
-            for_each = length(keys(lookup(rule.value, "apply_server_side_encryption_by_default", {}))) == 0 ? [] : [
-            lookup(rule.value, "apply_server_side_encryption_by_default", {})]
-
-            content {
-              sse_algorithm     = apply_server_side_encryption_by_default.value.sse_algorithm
-              kms_master_key_id = lookup(apply_server_side_encryption_by_default.value, "kms_master_key_id", null)
-            }
-          }
-        }
-      }
-    }
-  }
-
-  # Max 1 block - object_lock_configuration
   dynamic "object_lock_configuration" {
-    for_each = length(keys(var.object_lock_configuration)) == 0 ? [] : [var.object_lock_configuration]
-
+    for_each = length(keys(var.object_lock_configuration)) == 0 ? [] : [{}]
     content {
-      object_lock_enabled = object_lock_configuration.value.object_lock_enabled
-
-      dynamic "rule" {
-        for_each = length(keys(lookup(object_lock_configuration.value, "rule", {}))) == 0 ? [] : [lookup(object_lock_configuration.value, "rule", {})]
-
-        content {
-          default_retention {
-            mode  = lookup(lookup(rule.value, "default_retention", {}), "mode")
-            days  = lookup(lookup(rule.value, "default_retention", {}), "days", null)
-            years = lookup(lookup(rule.value, "default_retention", {}), "years", null)
-          }
-        }
-      }
+      object_lock_enabled = "Enabled"
     }
   }
 
+  tags          = var.tags
+  force_destroy = var.force_destroy
 }
 
 resource "aws_s3_bucket_policy" "this" {
@@ -452,4 +209,394 @@ resource "aws_s3_bucket_ownership_controls" "this" {
     aws_s3_bucket_public_access_block.this,
     aws_s3_bucket.this
   ]
+}
+
+resource "aws_s3_bucket_accelerate_configuration" "this" {
+  count  = var.acceleration_status != null ? 1 : 0
+  bucket = aws_s3_bucket.this[0].id
+  status = var.acceleration_status
+}
+
+# TODO: This should accept both ACL and Grant, exclusively
+resource "aws_s3_bucket_acl" "this" {
+  bucket = aws_s3_bucket.this[0].id
+  acl    = var.acl != "null" ? var.acl : null
+
+  dynamic "access_control_policy" {
+    for_each = try(jsondecode(var.access_control_policy), var.access_control_policy)
+
+    content {
+      dynamic "grant" {
+        for_each = lookup(access_control_policy.value, "grants", [])
+
+        content {
+          grantee {
+            email_address = lookup(grant.value, "email_address", null)
+            id            = lookup(grant.value, "id", null)
+            type          = lookup(grant.value, "type")
+            uri           = lookup(grant.value, "uri", null)
+          }
+
+          permission = lookup(grant.value, "permission")
+        }
+      }
+
+      owner {
+        id           = lookup(access_control_policy.value, "owner_id", null)
+        display_name = lookup(access_control_policy.value, "owner_name", null)
+      }
+    }
+  }
+}
+
+resource "aws_s3_bucket_cors_configuration" "this" {
+  bucket = aws_s3_bucket.this[0].id
+
+  dynamic "cors_rule" {
+    for_each = try(jsondecode(var.cors_rule), var.cors_rule)
+
+    content {
+      allowed_methods = cors_rule.value.allowed_methods
+      allowed_origins = cors_rule.value.allowed_origins
+      allowed_headers = lookup(cors_rule.value, "allowed_headers", null)
+      expose_headers  = lookup(cors_rule.value, "expose_headers", null)
+      max_age_seconds = lookup(cors_rule.value, "max_age_seconds", null)
+    }
+  }
+}
+
+
+resource "aws_s3_bucket_lifecycle_configuration" "this" {
+  bucket = aws_s3_bucket.this[0].id
+
+  dynamic "rule" {
+    for_each = try(jsondecode(var.lifecycle_rule), var.lifecycle_rule)
+
+    content {
+      id     = lookup(rule, "id", null)
+      status = lookup(rule, "status", null)
+
+      dynamic "abort_incomplete_multipart_upload" {
+        for_each = lookup(rule, "abort_incomplete_multipart_upload_days", null) == null ? [] : [lookup(rule, "abort_incomplete_multipart_upload_days")]
+
+        content {
+          days_after_initiation = abort_incomplete_multipart_upload.value
+        }
+      }
+
+      # Send empty map if `filter` is an empty map or absent entirely
+      dynamic "filter" {
+        for_each = length(keys(lookup(rule.value, "filter", {}))) == 0 ? [{}] : []
+
+        content {}
+      }
+
+      dynamic "filter" {
+        for_each = length(keys(lookup(rule.value, "filter", {}))) == 0 ? [] : [lookup(rule.value, "filter")]
+
+        content {
+          dynamic "and" {
+            for_each = lookup(filter.value, "prefix", "") != "" && length(keys(lookup(filter.value, "tags", {}))) > 1 ? [{ prefix : lookup(filter.value, "prefix"), tags : lookup(filter.value, "tags") }] : []
+
+            content {
+              tags   = lookup(and.value, "tags")
+              prefix = lookup(and.value, "prefix")
+            }
+          }
+
+          dynamic "tag" {
+            for_each = lookup(filter.value, "prefix", "") == "" && length(keys(lookup(filter.value, "tags", {}))) == 1 ? [element(lookup(filter.value, "tags"), 0)] : []
+
+            content {
+              key   = tag.key
+              value = tag.value
+            }
+          }
+
+          dynamic "prefix" {
+            for_each = lookup(filter.value, "prefix", "") != "" && length(keys(lookup(filter.value, "tags", {}))) == 0 ? [lookup(filter.value, "prefix")] : []
+
+            content {
+              prefix = prefix.value
+            }
+          }
+        }
+      }
+
+
+      # Max 1 block - expiration
+      dynamic "expiration" {
+        for_each = length(keys(lookup(rule, "expiration", {}))) == 0 ? [] : [lookup(rule, "expiration", {})]
+
+        content {
+          date                         = lookup(expiration.value, "date", null)
+          days                         = lookup(expiration.value, "days", null)
+          expired_object_delete_marker = lookup(expiration.value, "expired_object_delete_marker", null)
+        }
+      }
+
+      # Several blocks - transition
+      dynamic "transition" {
+        for_each = lookup(rule, "transition", [])
+
+        content {
+          date          = lookup(transition.value, "date", null)
+          days          = lookup(transition.value, "days", null)
+          storage_class = transition.value.storage_class
+        }
+      }
+
+      # Max 1 block - noncurrent_version_expiration
+      dynamic "noncurrent_version_expiration" {
+        for_each = length(keys(lookup(rule, "noncurrent_version_expiration", {}))) == 0 ? [] : [lookup(rule, "noncurrent_version_expiration", {})]
+
+        content {
+          days = lookup(noncurrent_version_expiration.value, "days", null)
+        }
+      }
+
+      # Several blocks - noncurrent_version_transition
+      dynamic "noncurrent_version_transition" {
+        for_each = lookup(rule, "noncurrent_version_transition", [])
+
+        content {
+          days          = lookup(noncurrent_version_transition.value, "days", null)
+          storage_class = noncurrent_version_transition.value.storage_class
+        }
+      }
+    }
+  }
+}
+
+resource "aws_s3_bucket_logging" "this" {
+  count = length(keys(var.logging)) == 0 ? 0 : 1
+
+  bucket        = aws_s3_bucket.this[0].id
+  target_bucket = lookup(var.logging, "target_bucket")
+  target_prefix = lookup(var.logging, "target_prefix", null)
+}
+
+resource "aws_s3_bucket_object_lock_configuration" "this" {
+  count  = length(keys(var.object_lock_configuration)) == 0 ? 0 : 1
+  bucket = aws_s3_bucket.this[0].id
+
+  object_lock_enabled = lookup(var.object_lock_configuration, "object_lock_enabled")
+
+
+  dynamic "rule" {
+    for_each = length(keys(lookup(var.object_lock_configuration, "rule", {}))) == 0 ? [] : [lookup(var.object_lock_configuration, "rule", {})]
+
+    content {
+      default_retention {
+        mode  = lookup(lookup(rule.value, "default_retention", {}), "mode")
+        days  = lookup(lookup(rule.value, "default_retention", {}), "days", null)
+        years = lookup(lookup(rule.value, "default_retention", {}), "years", null)
+      }
+    }
+  }
+}
+
+resource "aws_s3_bucket_replication_configuration" "this" {
+  bucket = aws_s3_bucket.this[0].id
+  role   = lookup(var.replication_configuration, "role", null)
+
+  dynamic "rule" {
+    for_each = lookup(var.replication_configuration, "rules", [])
+
+    content {
+      id       = lookup(rule.value, "id", null)
+      priority = lookup(rule.value, "priority", null)
+      prefix   = lookup(rule.value, "prefix", null)
+      status   = rule.value.status
+
+      dynamic "delete_marker_replication" {
+        for_each = length(keys(lookup(rule.value, "delete_marker_replication", {}))) == 0 ? [] : [lookup(rule.value, "delete_marker_replication", {})]
+
+        content {
+          status = lookup(delete_marker_replication.value, "status", null)
+        }
+      }
+
+      dynamic "destination" {
+        for_each = length(keys(lookup(rule.value, "destination", {}))) == 0 ? [] : [lookup(rule.value, "destination", {})]
+
+        content {
+          bucket        = destination.value.bucket
+          storage_class = lookup(destination.value, "storage_class", null)
+          account       = lookup(destination.value, "account_id", null)
+
+          dynamic "access_control_translation" {
+            for_each = length(keys(lookup(destination.value, "access_control_translation", {}))) == 0 ? [] : [lookup(destination.value, "access_control_translation", {})]
+
+            content {
+              owner = access_control_translation.value.owner
+            }
+          }
+
+          dynamic "encryption_configuration" {
+            for_each = lookup(destination, "replica_kms_key_id", null) == null ? [] : [lookup(destination, "replica_kms_key_id")]
+
+            content {
+              replica_kms_key_id = encryption_configuration.value
+            }
+          }
+
+          dynamic "replication_time" {
+            for_each = length(keys(lookup(destination.value, "replication_time", {}))) == 0 ? [] : [lookup(destination.value, "replication_time", {})]
+
+            content {
+              status = replication_time.value.status
+              time {
+                minutes = replication_time.value.minutes
+              }
+            }
+          }
+
+          dynamic "metrics" {
+            for_each = length(keys(lookup(destination.value, "metrics", {}))) == 0 ? [] : [lookup(destination.value, "metrics", {})]
+
+            content {
+              status = metrics.value.status
+
+              event_threshold {
+                minutes = metrics.value.minutes
+              }
+            }
+          }
+        }
+      }
+
+      dynamic "source_selection_criteria" {
+        for_each = length(keys(lookup(rule.value, "source_selection_criteria", {}))) == 0 ? [] : [lookup(rule.value, "source_selection_criteria", {})]
+
+        content {
+
+          dynamic "sse_kms_encrypted_objects" {
+            for_each = length(keys(lookup(source_selection_criteria.value, "sse_kms_encrypted_objects", {}))) == 0 ? [] : [lookup(source_selection_criteria.value, "sse_kms_encrypted_objects", {})]
+
+            content {
+              status = sse_kms_encrypted_objects.value
+            }
+          }
+
+          dynamic "replica_modifications" {
+            for_each = length(keys(lookup(source_selection_criteria.value, "replica_modifications", {}))) == 0 ? [] : [lookup(source_selection_criteria.value, "replica_modifications", {})]
+
+            content {
+              status = replica_modifications.value
+            }
+          }
+        }
+      }
+
+      # Send empty map if `filter` is an empty map or absent entirely
+      dynamic "filter" {
+        for_each = length(keys(lookup(rule.value, "filter", {}))) == 0 ? [{}] : []
+
+        content {}
+      }
+
+      # Send `filter` if it is present and has at least one field
+      dynamic "filter" {
+        for_each = length(keys(lookup(rule.value, "filter", {}))) != 0 ? [lookup(rule.value, "filter", {})] : []
+
+        content {
+          prefix = lookup(filter.value, "prefix", null)
+          tags   = lookup(filter.value, "tags", null)
+        }
+      }
+
+    }
+  }
+}
+
+resource "aws_s3_bucket_request_payment_configuration" "this" {
+  bucket = aws_s3_bucket.this[0].id
+  payer  = var.request_payer
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
+  bucket = aws_s3_bucket.this[0].id
+
+  dynamic "rule" {
+    for_each = length(keys(var.server_side_encryption_configuration)) == 0 ? [] : [var.server_side_encryption_configuration]
+
+    content {
+      bucket_key_enabled = lookup(rule.value, "bucket_key_enabled", null)
+
+      dynamic "apply_server_side_encryption_by_default" {
+        for_each = length(keys(lookup(rule.value, "apply_server_side_encryption_by_default", {}))) == 0 ? [] : [
+        lookup(rule.value, "apply_server_side_encryption_by_default", {})]
+
+        content {
+          sse_algorithm     = apply_server_side_encryption_by_default.value.sse_algorithm
+          kms_master_key_id = lookup(apply_server_side_encryption_by_default.value, "kms_master_key_id", null)
+        }
+      }
+    }
+  }
+}
+
+resource "aws_s3_bucket_versioning" "this" {
+  count  = length(keys(var.versioning)) == 0 ? 0 : 1
+  bucket = aws_s3_bucket.this[0].id
+
+  versioning_configuration {
+    status     = lookup(var.versioning, "status", null)
+    mfa_delete = lookup(var.versioning, "mfa_delete", null)
+  }
+}
+
+resource "aws_s3_bucket_website_configuration" "this" {
+  count  = length(keys(var.website)) == 0 ? 0 : 1
+  bucket = aws_s3_bucket.this[0].id
+
+  dynamic "index_document" {
+    for_each = length(keys(lookup(var.website, "index_document", ""))) == 0 ? [] : [lookup(var.website, "index_document")]
+    content {
+      suffix = index_document.value
+    }
+  }
+
+  dynamic "error_document" {
+    for_each = length(keys(lookup(var.website, "error_document", ""))) == 0 ? [] : [lookup(var.website, "error_document")]
+    content {
+      key = error_document.value
+    }
+  }
+
+  dynamic "redirect_all_requests_to" {
+    for_each = length(keys(lookup(var.website, "redirect_all_requests_to", {}))) == 0 ? [] : [lookup(var.website, "redirect_all_requests_to", {})]
+    content {
+      host_name = lookup(redirect_all_requests_to.value, "host_name", null)
+      protocol  = lookup(redirect_all_requests_to.value, "protocol", null)
+    }
+  }
+
+  dynamic "routing_rule" {
+    for_each = lookup(var.website, "routing_rules", [])
+    content {
+
+      dynamic "condition" {
+        for_each = length(keys(lookup(routing_rule.value, "condition", {}))) == 0 ? [] : [lookup(routing_rule.value, "condition")]
+
+        content {
+          http_error_code_returned_equals = lookup(condition.value, "http_error_code_returned_equals", null)
+          key_prefix_equals               = lookup(condition.value, "key_prefix_equals", null)
+        }
+      }
+
+      dynamic "redirect" {
+        for_each = length(keys(lookup(routing_rule.value, "redirect", {}))) == 0 ? [] : [lookup(routing_rule.value, "redirect")]
+
+        content {
+          host_name               = lookup(redirect.value, "host_name", null)
+          http_redirect_code      = lookup(redirect.value, "http_redirect_code", null)
+          protocol                = lookup(redirect.value, "protocol", null)
+          replace_key_prefix_with = lookup(redirect.value, "replace_key_prefix_with", null)
+          replace_key_with        = lookup(redirect.value, "replace_key_with", null)
+        }
+      }
+    }
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -90,7 +90,7 @@ variable "request_payer" {
 
 variable "website" {
   description = "Map containing static web-site hosting or redirect configuration."
-  type        = map(string)
+  type        = map(any)
   default     = {}
 }
 
@@ -112,7 +112,7 @@ variable "logging" {
   default     = {}
 }
 
-variable "grant" {
+variable "access_control_policy" {
   description = "An ACL policy grant. Conflicts with `acl`"
   type        = any
   default     = []

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.69"
+      version = "~> 4.4"
     }
   }
 }


### PR DESCRIPTION
## Description
The release of 4.x for the AWS provider brings a large number of breaking changes for the S3 bucket configuration. This PR uses the new explicit resources for various configuration options, while limiting changes on the module interface.

## Motivation and Context
These changes are needed to support the 4.x and newer versions of the AWS provider. This module is currently locked on the 3.x branch until these are completed

Works to resolve https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/issues/137

## Breaking Changes
There are a few breaking changes around the interface itself, as well as the structure of some of the variables. 

I will update with documentation around those soon.

## How Has This Been Tested?
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
TBD
