### PR TITLE
fix: Add lifecycle ignore changes on s3_bucket resource to prevent configuration loop

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -32,6 +32,7 @@ resource "aws_s3_bucket" "this" {
   lifecycle {
     ignore_changes = [
       acceleration_status,
+      acl,
       grant,
       cors_rule,
       lifecycle_rule,
@@ -40,6 +41,7 @@ resource "aws_s3_bucket" "this" {
       replication_configuration,
       request_payer,
       server_side_encryption_configuration,
+      versioning,
       website
     ]
   }

--- a/main.tf
+++ b/main.tf
@@ -28,6 +28,21 @@ resource "aws_s3_bucket" "this" {
       object_lock_enabled = "Enabled"
     }
   }
+
+  lifecycle {
+    ignore_changes = [
+      acceleration_status,
+      grant,
+      cors_rule,
+      lifecycle_rule,
+      logging,
+      object_lock_configuration[0].rule,
+      replication_configuration,
+      request_payer,
+      server_side_encryption_configuration,
+      website
+    ]
+  }
 }
 
 resource "aws_s3_bucket_logging" "this" {


### PR DESCRIPTION
add lifecycle ignore changes on s3_bucket resource to prevent configuration loop to fix https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/issues/144

## Description
add lifecycle ignore changes on s3_bucket resource for all new resources that are separate to prevent configuration loop

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes lifecycle loop

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

I tested it live because this is blocking my work 😞 