### PR TITLE
fix: Key `host_name` on website routing rules redirect

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -129,7 +129,7 @@ resource "aws_s3_bucket_website_configuration" "this" {
       }
 
       redirect {
-        host_name               = try(routing_rule.value.redirect["hostname"], null)
+        host_name               = try(routing_rule.value.redirect["host_name"], null)
         http_redirect_code      = try(routing_rule.value.redirect["http_redirect_code"], null)
         protocol                = try(routing_rule.value.redirect["protocol"], null)
         replace_key_prefix_with = try(routing_rule.value.redirect["replace_key_prefix_with"], null)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Change the `hostname` key referenced by the redirect configuration on website routing rules from `hostname` to `host_name`. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The AWS provider attribute name is `host_name`, and it's also used as `host_name` in the complete example.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
