### PR TITLE
fix: Allow setup eventbridge without notifications

### DIFF
--- a/modules/notification/main.tf
+++ b/modules/notification/main.tf
@@ -7,7 +7,7 @@ locals {
 }
 
 resource "aws_s3_bucket_notification" "this" {
-  count = var.create && (length(var.lambda_notifications) > 0 || length(var.sqs_notifications) > 0 || length(var.sns_notifications) > 0) ? 1 : 0
+  count = var.create ? 1 : 0
 
   bucket = var.bucket
 


### PR DESCRIPTION
## Description
Impossible to use notification module only for enable/disable S3 EventBridge. You need to set at least one notification option.

## Motivation and Context
PR allows setup eventbridge without adding notification options

## Breaking Changes
No breaking changes. It was removed validation of length of arrays of notifications settings. Without this validation dynamic blocks  will still not executed because of empty arrays

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request

