### PR TITLE
fix: Revert change for grant in aws_s3_bucket_acl resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -58,7 +58,7 @@ resource "aws_s3_bucket_acl" "this" {
   acl = var.acl == "null" ? null : var.acl
 
   dynamic "access_control_policy" {
-    for_each = length(local.grants) > 0 ? local.grants : []
+    for_each = length(local.grants) > 0 ? [true] : []
 
     content {
       dynamic "grant" {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This one is the revert for my previous PR, I've misconfigured my local setup this is why it looked like it worked, actually it introduced another issue with multiple `access_control_policy` blocks. I am really sorry for that one.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
None.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
