### PR TITLE
Remove hardcoded aws partition in notifications sub-module

### DIFF
--- a/examples/notification/README.md
+++ b/examples/notification/README.md
@@ -37,9 +37,11 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_all_notifications"></a> [all\_notifications](#module\_all\_notifications) | ../../modules/notification | n/a |
+| <a name="module_china_notifications"></a> [china\_notifications](#module\_china\_notifications) | ../../modules/notification | n/a |
 | <a name="module_lambda_function1"></a> [lambda\_function1](#module\_lambda\_function1) | terraform-aws-modules/lambda/aws | ~> 3.0 |
 | <a name="module_lambda_function2"></a> [lambda\_function2](#module\_lambda\_function2) | terraform-aws-modules/lambda/aws | ~> 3.0 |
 | <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | ../../ | n/a |
+| <a name="module_s3_bucket_beijing"></a> [s3\_bucket\_beijing](#module\_s3\_bucket\_beijing) | ../../ | n/a |
 | <a name="module_sns_topic1"></a> [sns\_topic1](#module\_sns\_topic1) | terraform-aws-modules/sns/aws | ~> 3.0 |
 | <a name="module_sns_topic2"></a> [sns\_topic2](#module\_sns\_topic2) | terraform-aws-modules/sns/aws | ~> 3.0 |
 

--- a/examples/notification/main.tf
+++ b/examples/notification/main.tf
@@ -12,6 +12,7 @@ provider "aws" {
 locals {
   bucket_name = "s3-bucket-${random_pet.this.id}"
   region      = "eu-west-1"
+  #region      = "cn-north-1"
 }
 
 resource "random_pet" "this" {
@@ -22,6 +23,15 @@ module "s3_bucket" {
   source = "../../"
 
   bucket        = local.bucket_name
+  force_destroy = true
+}
+
+module "s3_bucket_beijing" {
+  source = "../../"
+
+  create_bucket = local.region == "cn-north-1" ? true : false
+
+  bucket        = "${local.bucket_name}-cn-north-1"
   force_destroy = true
 }
 
@@ -52,6 +62,8 @@ module "lambda_function1" {
   handler       = "index.lambda_handler"
   runtime       = "python3.8"
 
+  ephemeral_storage_size = local.region == "cn-north-1" ? null : 512
+
   create_package         = false
   local_existing_package = local.downloaded
 }
@@ -63,6 +75,8 @@ module "lambda_function2" {
   function_name = "${random_pet.this.id}-lambda2"
   handler       = "index.lambda_handler"
   runtime       = "python3.8"
+
+  ephemeral_storage_size = local.region == "cn-north-1" ? null : 512
 
   create_package         = false
   local_existing_package = local.downloaded
@@ -83,7 +97,7 @@ module "sns_topic2" {
 }
 
 resource "aws_sqs_queue" "this" {
-  count = 2
+  count = local.region == "cn-north-1" ? 3 : 2
   name  = "${random_pet.this.id}-${count.index}"
 }
 
@@ -159,4 +173,29 @@ module "all_notifications" {
 
   # Creation of policy is handled outside of the module
   create_sqs_policy = false
+}
+
+module "china_notifications" {
+  source = "../../modules/notification"
+
+  create = local.region == "cn-north-1" ? true : false
+
+  bucket = module.s3_bucket_beijing.s3_bucket_id
+
+  eventbridge = true
+
+  # Common error - Error putting S3 notification configuration: InvalidArgument: Configuration is ambiguously defined. Cannot have overlapping suffixes in two rules if the prefixes are overlapping for the same event type.
+  sqs_notifications = {
+    sqs1 = {
+      queue_arn     = try(aws_sqs_queue.this[2].arn, aws_sqs_queue.this[0].arn)
+      events        = ["s3:ObjectCreated:Put"]
+      filter_prefix = "prefix2/"
+      filter_suffix = ".txt"
+
+      #      queue_id =  aws_sqs_queue.this[0].id // optional
+    }
+  }
+
+  # Creation of policy is handled inside of the module
+  create_sqs_policy = local.region == "cn-north-1" ? true : false
 }

--- a/examples/notification/main.tf
+++ b/examples/notification/main.tf
@@ -62,6 +62,7 @@ module "lambda_function1" {
   handler       = "index.lambda_handler"
   runtime       = "python3.8"
 
+  # ephemeral_storage not supported in China
   ephemeral_storage_size = local.region == "cn-north-1" ? null : 512
 
   create_package         = false
@@ -76,6 +77,7 @@ module "lambda_function2" {
   handler       = "index.lambda_handler"
   runtime       = "python3.8"
 
+  # ephemeral_storage not supported in China
   ephemeral_storage_size = local.region == "cn-north-1" ? null : 512
 
   create_package         = false

--- a/modules/notification/README.md
+++ b/modules/notification/README.md
@@ -31,6 +31,7 @@ No modules.
 | [aws_arn.queue](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/arn) | data source |
 | [aws_iam_policy_document.sns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.sqs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ## Inputs
 

--- a/modules/notification/main.tf
+++ b/modules/notification/main.tf
@@ -1,5 +1,7 @@
+data "aws_partition" "this" {}
+
 locals {
-  bucket_arn = coalesce(var.bucket_arn, "arn:aws:s3:::${var.bucket}")
+  bucket_arn = coalesce(var.bucket_arn, "arn:${data.aws_partition.this.partition}:s3:::${var.bucket}")
 
   # Convert from "arn:aws:sqs:eu-west-1:835367859851:bold-starling-0" into "https://sqs.eu-west-1.amazonaws.com/835367859851/bold-starling-0" if queue_id was not specified
   # queue_url used in aws_sqs_queue_policy is not the same as arn which is used in all other places


### PR DESCRIPTION
## Description
In the notifications sub-module, the AWS partition in local.bucket_arn, is hardcoded to "aws". When deploying this module in China regions, with create_sqs_policy set to true, it fails with the error:

`Error: error putting S3 Bucket Notification Configuration: InvalidArgument: Unable to validate the following destination configurations`

This change replaces the hardcoded value with a data source to make it dynamic and allows for successful deployment in China.

## Motivation and Context
To fix error messages when deploying to AWS China.

This should resolve
https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/issues/159

## Breaking Changes
No, this is a non-breaking change.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects

Existing notifications example deployed prior to my changes. Updated module with my changes and re-deployed, Terraform reported no changes required.

Added China-specific resources to the example, behind a conditional check. Deployed resources to cn-north-1 region with my changes and I no longer get any errors.

- [x] I have executed `pre-commit run -a` on my pull request