### PR TITLE
fix: Remove deprecated ignores_changes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -21,23 +21,6 @@ resource "aws_s3_bucket" "this" {
   force_destroy       = var.force_destroy
   object_lock_enabled = var.object_lock_enabled
   tags                = var.tags
-
-  lifecycle {
-    ignore_changes = [
-      acceleration_status,
-      acl,
-      grant,
-      cors_rule,
-      lifecycle_rule,
-      logging,
-      object_lock_configuration,
-      replication_configuration,
-      request_payer,
-      server_side_encryption_configuration,
-      versioning,
-      website
-    ]
-  }
 }
 
 resource "aws_s3_bucket_logging" "this" {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Remove ignores_changes that are related to deprecated parameters.
Fixes #174 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Some S3 bucket parameters got their own resources instead of being simple parameters.
Therefore, the ignore_changes is related to non-existent parameters.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

No breaking change.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
