### PR TITLE
feat: Add a new output s3_bucket_versioning_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ No modules.
 | <a name="output_s3_bucket_hosted_zone_id"></a> [s3\_bucket\_hosted\_zone\_id](#output\_s3\_bucket\_hosted\_zone\_id) | The Route 53 Hosted Zone ID for this bucket's region. |
 | <a name="output_s3_bucket_id"></a> [s3\_bucket\_id](#output\_s3\_bucket\_id) | The name of the bucket. |
 | <a name="output_s3_bucket_region"></a> [s3\_bucket\_region](#output\_s3\_bucket\_region) | The AWS region this bucket resides in. |
+| <a name="output_s3_bucket_versioning_id"></a> [s3\_bucket\_versioning\_id](#output\_s3\_bucket\_versioning\_id) | The bucket versioning id. This is the bucket id or bucket and expected\_bucket\_owner separated by a comma (,) if the latter is provided. This can be used when other resources depend on the versioning to be enabled first. |
 | <a name="output_s3_bucket_website_domain"></a> [s3\_bucket\_website\_domain](#output\_s3\_bucket\_website\_domain) | The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records. |
 | <a name="output_s3_bucket_website_endpoint"></a> [s3\_bucket\_website\_endpoint](#output\_s3\_bucket\_website\_endpoint) | The website endpoint, if the bucket is configured with a website. If not, this will be an empty string. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/outputs.tf
+++ b/outputs.tf
@@ -37,3 +37,8 @@ output "s3_bucket_website_domain" {
   description = "The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records."
   value       = try(aws_s3_bucket_website_configuration.this[0].website_domain, "")
 }
+
+output "s3_bucket_versioning_id" {
+  description = "The bucket versioning id. This is the bucket id or bucket and expected_bucket_owner separated by a comma (,) if the latter is provided. This can be used when other resources depend on the versioning to be enabled first."
+  value       = try(aws_s3_bucket_versioning.this[0].id, "")
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

A new output containing the bucket ID by using `aws_s3_bucket_versioning`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This new output will allow having an implicit dependency between the versioning and the resources that need it outside the module (an S3 bucket object, for example). The caller will then reference this output instead of `s3_bucket_id` (depending on if it uses the `expected_bucket_owner` or not).

This is particularly useful when you create a bucket, and S3 objects in the same Terraform stack with the versioning enabled. This output can be referenced in a null resource [to wait 15mn before creating the objects.](https://docs.aws.amazon.com/AmazonS3/latest/userguide/manage-versioning-examples.html#:~:text=If%20you%20enable%20versioning%20on%20a%20bucket%20for%20the%20first%20time%2C%20it%20might%20take%20a%20short%20amount%20of%20time%20for%20the%20change%20to%20be%20fully%20propagated.%20We%20recommend%20that%20you%20wait%20for%2015%20minutes%20after%20enabling%20versioning%20before%20issuing%20write%20operations%20(PUT%20or%20DELETE)%20on%20objects%20in%20the%20bucket.)

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

No breaking change

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
