### PR TITLE
feat: Enable jsonencode support for replication config

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -339,13 +339,13 @@ resource "aws_s3_bucket_object_lock_configuration" "this" {
 }
 
 resource "aws_s3_bucket_replication_configuration" "this" {
-  count = local.create_bucket && length(keys(var.replication_configuration)) > 0 ? 1 : 0
+  count = local.create_bucket && length(keys(local.replication_configuration)) > 0 ? 1 : 0
 
   bucket = aws_s3_bucket.this[0].id
-  role   = var.replication_configuration["role"]
+  role   = local.replication_configuration["role"]
 
   dynamic "rule" {
-    for_each = flatten(try([var.replication_configuration["rule"]], [var.replication_configuration["rules"]], []))
+    for_each = flatten(try([local.replication_configuration["rule"]], [local.replication_configuration["rules"]], []))
 
     content {
       id       = try(rule.value.id, null)

--- a/main.tf
+++ b/main.tf
@@ -8,11 +8,12 @@ locals {
   attach_policy = var.attach_require_latest_tls_policy || var.attach_elb_log_delivery_policy || var.attach_lb_log_delivery_policy || var.attach_deny_insecure_transport_policy || var.attach_inventory_destination_policy || var.attach_policy
 
   # Variables with type `any` should be jsonencode()'d when value is coming from Terragrunt
-  grants               = try(jsondecode(var.grant), var.grant)
-  cors_rules           = try(jsondecode(var.cors_rule), var.cors_rule)
-  lifecycle_rules      = try(jsondecode(var.lifecycle_rule), var.lifecycle_rule)
-  intelligent_tiering  = try(jsondecode(var.intelligent_tiering), var.intelligent_tiering)
-  metric_configuration = try(jsondecode(var.metric_configuration), var.metric_configuration)
+  grants                    = try(jsondecode(var.grant), var.grant)
+  cors_rules                = try(jsondecode(var.cors_rule), var.cors_rule)
+  lifecycle_rules           = try(jsondecode(var.lifecycle_rule), var.lifecycle_rule)
+  intelligent_tiering       = try(jsondecode(var.intelligent_tiering), var.intelligent_tiering)
+  metric_configuration      = try(jsondecode(var.metric_configuration), var.metric_configuration)
+  replication_configuration = try(jsondecode(var.replication_configuration), var.replication_configuration)
 }
 
 resource "aws_s3_bucket" "this" {


### PR DESCRIPTION
## Description

Enable jsonencode support for replication config

## Motivation and Context

```
locals {
  replication_config = jsonencode({
    role = var.role_arn
    rules = [
      {
        id       = "sync to staging"
        status   = true
        priority = 0

        delete_marker_replication = true

        destination = {
          bucket     = "arn:aws:s3:::test2"
          account_id = "xxxxxx"
          access_control_translation = {
            owner = "Destination"
          }
        }
      },
    ]
  })
}

module "bucket" {
  source                  = "terraform-aws-modules/s3-bucket/aws"
  version                 = "3.6.x"
  bucket                  = "test"
  replication_configuration = var.env == "prod" ? local.replication_config : "{}"
}
```

## Breaking Changes

No.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

