### PR TITLE
fix: Error in S3-Notification module

### DIFF
--- a/modules/notification/main.tf
+++ b/modules/notification/main.tf
@@ -60,7 +60,7 @@ resource "aws_s3_bucket_notification" "this" {
 
 # Lambda
 resource "aws_lambda_permission" "allow" {
-  for_each = var.lambda_notifications
+  for_each = var.create ? var.lambda_notifications : {}
 
   statement_id_prefix = "AllowLambdaS3BucketNotification-"
   action              = "lambda:InvokeFunction"


### PR DESCRIPTION
## Description
Added `create` conditional to `aws_lambda_permission` in `s3-notification` module

## Motivation and Context
Fixes #212 

## Breaking Changes
No breaking changes that I can see

## How Has This Been Tested?
Tested in my production environment
