### PR TITLE
Prevent accidentally creating lifecycle rule without filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,67 @@ module "s3_bucket" {
 }
 ```
 
+## Expiration lifecycle rules for the whole bucket
+
+To prevent accidentally creating a lifecycle rule for the whole bucket that could remove all of your files, you must pass the `expire_all_objects_in_bucket = true` option.
+
+```hcl
+# This S3 bucket has an expiration lifecycle rule only for the specified prefix
+module "s3_bucket" {
+  source = "terraform-aws-modules/s3-bucket/aws"
+
+  lifecycle_rule = [
+    {
+      enabled = true
+
+      filter = {
+        prefix = "prefix-to-cleanup/"
+      }
+
+      expiration = {
+        days = 1
+      }
+    }
+  ]
+}
+```
+
+```hcl
+# This S3 bucket has an expiration lifecycle for the whole bucket
+module "s3_bucket" {
+  source = "terraform-aws-modules/s3-bucket/aws"
+
+  lifecycle_rule = [
+    {
+      enabled = true
+
+      expire_all_objects_in_bucket = true
+      expiration = {
+        days = 1
+      }
+    }
+  ]
+}
+```
+
+```hcl
+# This S3 bucket does NOT have ANY expiration lifecycle rule
+module "s3_bucket" {
+  source = "terraform-aws-modules/s3-bucket/aws"
+
+  lifecycle_rule = [
+    {
+      enabled = true
+
+      # no option or expire_all_objects_in_bucket = false
+      expiration = {
+        days = 1
+      }
+    }
+  ]
+}
+```
+
 ## Terragrunt and `variable "..." { type = any }`
 
 There is a bug [#1211](https://github.com/gruntwork-io/terragrunt/issues/1211) in Terragrunt related to the way how the variables of type `any` are passed to Terraform.

--- a/main.tf
+++ b/main.tf
@@ -237,7 +237,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "this" {
 
       # Max 1 block - expiration
       dynamic "expiration" {
-        for_each = try(flatten([rule.value.expiration]), [])
+        for_each = try(rule.value.expire_all_objects_in_bucket, false) == true || try(rule.value.filter.prefix, rule.value.filter.object_size_less_than, rule.value.filter.object_size_greater_than, rule.value.filter.tags, null) != null ? try(flatten([rule.value.expiration]), []) : []
 
         content {
           date                         = try(expiration.value.date, null)


### PR DESCRIPTION
## Description
Added extra guard option to create lifecycle rule for expiration whole bucket

## Motivation and Context
In our case, we created a bucket without any filter prefix, which causes expiration of about 1,5TB of data in bucket.
We had code like snippet bellow
```hcl
module "s3_bucket" {
  source = "terraform-aws-modules/s3-bucket/aws"

  lifecycle_rule = [
    {
      enabled = true
       prefix = "prefix-to-cleanup/"
      
      expiration = {
        days = 1
      }
    }
  ]
}
```
There is a missing `filter` section wrapping `prefix`. Sadly terraform does not throw any error that config is inaccurate. That code created lifecycle rules for the whole bucket.

We wanted to be sure not to make the same mistake again and create some kind of guard before this situation. Without passing extra option, no expiration section will be created - that should be less pain than losing data ;)

Passing one extra option should not be a big deal - AWS Console have a similar checkbox to prevent creating rule for the whole bucket.

## Breaking Changes
Conditionaly/Partialy - if someone wanted to create lifecycle to cleanup whole bucket it is needed to pass extra option.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
