### PR TITLE
feat: Allow setting id parameter in notification object

### DIFF
--- a/modules/notification/main.tf
+++ b/modules/notification/main.tf
@@ -19,7 +19,7 @@ resource "aws_s3_bucket_notification" "this" {
     for_each = var.lambda_notifications
 
     content {
-      id                  = lambda_function.key
+      id                  = try(lambda_function.value.id, lambda_function.key)
       lambda_function_arn = lambda_function.value.function_arn
       events              = lambda_function.value.events
       filter_prefix       = try(lambda_function.value.filter_prefix, null)
@@ -31,7 +31,7 @@ resource "aws_s3_bucket_notification" "this" {
     for_each = var.sqs_notifications
 
     content {
-      id            = queue.key
+      id            = try(queue.value.id, queue.key)
       queue_arn     = queue.value.queue_arn
       events        = queue.value.events
       filter_prefix = try(queue.value.filter_prefix, null)
@@ -43,7 +43,7 @@ resource "aws_s3_bucket_notification" "this" {
     for_each = var.sns_notifications
 
     content {
-      id            = topic.key
+      id            = try(topic.value.id, topic.key)
       topic_arn     = topic.value.topic_arn
       events        = topic.value.events
       filter_prefix = try(topic.value.filter_prefix, null)


### PR DESCRIPTION
## Description
Allow setting the id parameter inside the notification block.

## Motivation and Context
When configuring bucket notifications using map type inside another map, like in the example [here](https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/blob/bf80a09f0955e6542a6ae8f3b7fa8fbd612148ea/examples/notification/main.tf#L145), there is no control on the order of the notifications.

This can cause terraform to change the resource and replace the notifications order after importing bucket notification, because the state contains list of sorted notifications and the map order can be different.

```terraform
sns_notifications = {
  ios = {
    topic_arn     = "arn:aws:sns:eu-west-1:123456789012:ios-log-upload"
    events        = ["s3:ObjectCreated:*"]
    filter_prefix = "ios/"
  },
  android = {
    topic_arn     = "arn:aws:sns:eu-west-1:123456789012:android-log-upload"
    events        = ["s3:ObjectCreated:*"]
    filter_prefix = "android/"
  }
}
```

```terraform
 # aws_s3_bucket_notification.this[0] will be updated in-place
  ~ resource "aws_s3_bucket_notification" "this" {
        id          = "example-bucket-id"
        # (2 unchanged attributes hidden)

      ~ topic {
          ~ filter_prefix = "ios/" -> "android/"
          ~ id            = "ios" -> "android"
          ~ topic_arn     = "arn:aws:sns:eu-west-1:123456789012:ios-log-upload" -> "arn:aws:sns:eu-west-1:123456789012:android-log-upload"
            # (1 unchanged attribute hidden)
        }
      ~ topic {
          ~ filter_prefix = "android/" -> "ios/"
          ~ id            = "android" -> "ios"
          ~ topic_arn     = "arn:aws:sns:eu-west-1:123456789012:android-log-upload" -> "arn:aws:sns:eu-west-1:123456789012:ios-log-upload"
            # (1 unchanged attribute hidden)
        }
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

This made me configure the notifications in a list rather then map type, but then I realized that the id parameter is not configurable, and will be the key (index) of the object in the list.

```terraform
sns_notifications = [
    {
      topic_arn     = "arn:aws:sns:eu-west-1:123456789012:ios-log-upload"
      events        = ["s3:ObjectCreated:*"]
      filter_prefix = "ios/"
      id            = "ios"
    },
    {
      topic_arn     = "arn:aws:sns:eu-west-1:123456789012:android-log-upload"
      events        = ["s3:ObjectCreated:*"]
      filter_prefix = "android/"
      id            = "android"
    }
  ]
```
```terraform
Terraform will perform the following actions:

  # aws_s3_bucket_notification.this[0] will be updated in-place
  ~ resource "aws_s3_bucket_notification" "this" {
        id          = "example-bucket-id"
        # (2 unchanged attributes hidden)

      ~ topic {
          ~ id            = "ios" -> "0"
            # (3 unchanged attributes hidden)
        }
      ~ topic {
          ~ id            = "android" -> "1"
            # (3 unchanged attributes hidden)
        }
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

The PR will make it possible to configure the id inside each notification block and will allow use of list type over map when you need to control the order of the notifications.

## Breaking Changes
No breaking changes.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [ ] I have executed `pre-commit run -a` on my pull request
