### PR TITLE
fixes attach_deny_insecure_transport_policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -808,7 +808,7 @@ resource "aws_s3_bucket_public_access_block" "this" {
 resource "aws_s3_bucket_ownership_controls" "this" {
   count = local.create_bucket && var.control_object_ownership ? 1 : 0
 
-  bucket = local.attach_policy ? aws_s3_bucket_policy.this[0].id : aws_s3_bucket.this[0].id
+  bucket = aws_s3_bucket.this[0].id
 
   rule {
     object_ownership = var.object_ownership


### PR DESCRIPTION
When attempting to apply `attach_deny_insecure_transport_policy` on some buckets the module wants to recreate the bucket due to the owner policy even when it's set correctly. This PR fixes that. 

Error message:
```  # module.${bucket}.module.s3_bucket.aws_s3_bucket_ownership_controls.this[0] must be replaced
-/+ resource "aws_s3_bucket_ownership_controls" "this" {
      ~ bucket = "${bucket}" # forces replacement -> (known after apply) # forces replacement
      ~ id     = "${bucket}" -> (known after apply)```

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
