### PR TITLE
feat: Add "deny unencrypted object uploads" and "incorrect encryption headers" bucket policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,9 @@ No modules.
 | [aws_canonical_user_id.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/canonical_user_id) | data source |
 | [aws_iam_policy_document.access_log_delivery](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.combined](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.deny_incorrect_encryption_headers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.deny_insecure_transport](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.deny_unencrypted_object_uploads](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.elb_log_delivery](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.inventory_and_analytics_destination_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.lb_log_delivery](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -187,7 +189,9 @@ No modules.
 | <a name="input_analytics_source_bucket_arn"></a> [analytics\_source\_bucket\_arn](#input\_analytics\_source\_bucket\_arn) | The analytics source bucket ARN. | `string` | `null` | no |
 | <a name="input_attach_access_log_delivery_policy"></a> [attach\_access\_log\_delivery\_policy](#input\_attach\_access\_log\_delivery\_policy) | Controls if S3 bucket should have S3 access log delivery policy attached | `bool` | `false` | no |
 | <a name="input_attach_analytics_destination_policy"></a> [attach\_analytics\_destination\_policy](#input\_attach\_analytics\_destination\_policy) | Controls if S3 bucket should have bucket analytics destination policy attached. | `bool` | `false` | no |
+| <a name="input_attach_deny_incorrect_encryption_headers"></a> [attach\_deny\_incorrect\_encryption\_headers](#input\_attach\_deny\_incorrect\_encryption\_headers) | Controls if S3 bucket should deny incorrect encryption headers policy attached. | `bool` | `false` | no |
 | <a name="input_attach_deny_insecure_transport_policy"></a> [attach\_deny\_insecure\_transport\_policy](#input\_attach\_deny\_insecure\_transport\_policy) | Controls if S3 bucket should have deny non-SSL transport policy attached | `bool` | `false` | no |
+| <a name="input_attach_deny_unencrypted_object_uploads"></a> [attach\_deny\_unencrypted\_object\_uploads](#input\_attach\_deny\_unencrypted\_object\_uploads) | Controls if S3 bucket should deny unencrypted object uploads policy attached. | `bool` | `false` | no |
 | <a name="input_attach_elb_log_delivery_policy"></a> [attach\_elb\_log\_delivery\_policy](#input\_attach\_elb\_log\_delivery\_policy) | Controls if S3 bucket should have ELB log delivery policy attached | `bool` | `false` | no |
 | <a name="input_attach_inventory_destination_policy"></a> [attach\_inventory\_destination\_policy](#input\_attach\_inventory\_destination\_policy) | Controls if S3 bucket should have bucket inventory destination policy attached. | `bool` | `false` | no |
 | <a name="input_attach_lb_log_delivery_policy"></a> [attach\_lb\_log\_delivery\_policy](#input\_attach\_lb\_log\_delivery\_policy) | Controls if S3 bucket should have ALB/NLB log delivery policy attached | `bool` | `false` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -132,10 +132,12 @@ module "s3_bucket" {
   }
 
   # Bucket policies
-  attach_policy                         = true
-  policy                                = data.aws_iam_policy_document.bucket_policy.json
-  attach_deny_insecure_transport_policy = true
-  attach_require_latest_tls_policy      = true
+  attach_policy                            = true
+  policy                                   = data.aws_iam_policy_document.bucket_policy.json
+  attach_deny_insecure_transport_policy    = true
+  attach_require_latest_tls_policy         = true
+  attach_deny_incorrect_encryption_headers = true
+  attach_deny_unencrypted_object_uploads   = true
 
   # S3 bucket-level Public Access Block configuration (by default now AWS has made this default as true for S3 bucket-level block public access)
   # block_public_acls       = true

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -71,11 +71,13 @@ module "log_bucket" {
 
   control_object_ownership = true
 
-  attach_elb_log_delivery_policy        = true
-  attach_lb_log_delivery_policy         = true
-  attach_access_log_delivery_policy     = true
-  attach_deny_insecure_transport_policy = true
-  attach_require_latest_tls_policy      = true
+  attach_elb_log_delivery_policy           = true
+  attach_lb_log_delivery_policy            = true
+  attach_access_log_delivery_policy        = true
+  attach_deny_insecure_transport_policy    = true
+  attach_require_latest_tls_policy         = true
+  attach_deny_incorrect_encryption_headers = true
+  attach_deny_unencrypted_object_uploads   = true
 
   access_log_delivery_policy_source_accounts = [data.aws_caller_identity.current.account_id]
   access_log_delivery_policy_source_buckets  = ["arn:aws:s3:::${local.bucket_name}"]

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -71,13 +71,11 @@ module "log_bucket" {
 
   control_object_ownership = true
 
-  attach_elb_log_delivery_policy           = true
-  attach_lb_log_delivery_policy            = true
-  attach_access_log_delivery_policy        = true
-  attach_deny_insecure_transport_policy    = true
-  attach_require_latest_tls_policy         = true
-  attach_deny_incorrect_encryption_headers = true
-  attach_deny_unencrypted_object_uploads   = true
+  attach_elb_log_delivery_policy        = true
+  attach_lb_log_delivery_policy         = true
+  attach_access_log_delivery_policy     = true
+  attach_deny_insecure_transport_policy = true
+  attach_require_latest_tls_policy      = true
 
   access_log_delivery_policy_source_accounts = [data.aws_caller_identity.current.account_id]
   access_log_delivery_policy_source_buckets  = ["arn:aws:s3:::${local.bucket_name}"]

--- a/main.tf
+++ b/main.tf
@@ -797,7 +797,7 @@ data "aws_iam_policy_document" "require_latest_tls" {
 }
 
 data "aws_iam_policy_document" "deny_incorrect_encryption_headers" {
-  count = local.create_bucket && length(keys(var.server_side_encryption_configuration)) > 0 && var.attach_deny_incorrect_encryption_headers ? 1 : 0
+  count = local.create_bucket && var.attach_deny_incorrect_encryption_headers ? 1 : 0
 
   statement {
     sid    = "denyIncorrectEncryptionHeaders"
@@ -819,13 +819,13 @@ data "aws_iam_policy_document" "deny_incorrect_encryption_headers" {
     condition {
       test     = "StringNotEquals"
       variable = "s3:x-amz-server-side-encryption"
-      values   = var.server_side_encryption_configuration.rule.apply_server_side_encryption_by_default.sse_algorithm == "aws:kms" ? ["aws:kms"] : ["AES256"]
+      values   = try(var.server_side_encryption_configuration.rule.apply_server_side_encryption_by_default.sse_algorithm, null) == "aws:kms" ? ["aws:kms"] : ["AES256"]
     }
   }
 }
 
 data "aws_iam_policy_document" "deny_unencrypted_object_uploads" {
-  count = local.create_bucket && length(keys(var.server_side_encryption_configuration)) > 0 && var.attach_deny_unencrypted_object_uploads ? 1 : 0
+  count = local.create_bucket && var.attach_deny_unencrypted_object_uploads ? 1 : 0
 
   statement {
     sid    = "denyUnencryptedObjectUploads"

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ data "aws_partition" "current" {}
 locals {
   create_bucket = var.create_bucket && var.putin_khuylo
 
-  attach_policy = var.attach_require_latest_tls_policy || var.attach_elb_log_delivery_policy || var.attach_lb_log_delivery_policy || var.attach_deny_insecure_transport_policy || var.attach_inventory_destination_policy || var.attach_policy
+  attach_policy = var.attach_require_latest_tls_policy || var.attach_elb_log_delivery_policy || var.attach_lb_log_delivery_policy || var.attach_deny_insecure_transport_policy || var.attach_inventory_destination_policy || var.attach_deny_incorrect_encryption_headers || var.attach_deny_unencrypted_object_uploads || var.attach_policy
 
   # Variables with type `any` should be jsonencode()'d when value is coming from Terragrunt
   grants               = try(jsondecode(var.grant), var.grant)
@@ -533,6 +533,8 @@ data "aws_iam_policy_document" "combined" {
     var.attach_access_log_delivery_policy ? data.aws_iam_policy_document.access_log_delivery[0].json : "",
     var.attach_require_latest_tls_policy ? data.aws_iam_policy_document.require_latest_tls[0].json : "",
     var.attach_deny_insecure_transport_policy ? data.aws_iam_policy_document.deny_insecure_transport[0].json : "",
+    var.attach_deny_unencrypted_object_uploads ? data.aws_iam_policy_document.deny_unencrypted_object_uploads[0].json : "",
+    var.attach_deny_incorrect_encryption_headers ? data.aws_iam_policy_document.deny_incorrect_encryption_headers[0].json : "",
     var.attach_inventory_destination_policy || var.attach_analytics_destination_policy ? data.aws_iam_policy_document.inventory_and_analytics_destination_policy[0].json : "",
     var.attach_policy ? var.policy : ""
   ])
@@ -790,6 +792,62 @@ data "aws_iam_policy_document" "require_latest_tls" {
       values = [
         "1.2"
       ]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "deny_incorrect_encryption_headers" {
+  count = local.create_bucket && length(keys(var.server_side_encryption_configuration)) > 0 && var.attach_deny_incorrect_encryption_headers ? 1 : 0
+
+  statement {
+    sid    = "denyIncorrectEncryptionHeaders"
+    effect = "Deny"
+
+    actions = [
+      "s3:PutObject"
+    ]
+
+    resources = [
+      "${aws_s3_bucket.this[0].arn}/*"
+    ]
+
+    principals {
+      identifiers = ["*"]
+      type        = "*"
+    }
+
+    condition {
+      test     = "StringNotEquals"
+      variable = "s3:x-amz-server-side-encryption"
+      values   = var.server_side_encryption_configuration.rule.apply_server_side_encryption_by_default.sse_algorithm == "aws:kms" ? ["aws:kms"] : ["AES256"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "deny_unencrypted_object_uploads" {
+  count = local.create_bucket && length(keys(var.server_side_encryption_configuration)) > 0 && var.attach_deny_unencrypted_object_uploads ? 1 : 0
+
+  statement {
+    sid    = "denyUnencryptedObjectUploads"
+    effect = "Deny"
+
+    actions = [
+      "s3:PutObject"
+    ]
+
+    resources = [
+      "${aws_s3_bucket.this[0].arn}/*"
+    ]
+
+    principals {
+      identifiers = ["*"]
+      type        = "*"
+    }
+
+    condition {
+      test     = "Null"
+      variable = "s3:x-amz-server-side-encryption"
+      values   = [true]
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -58,6 +58,18 @@ variable "attach_analytics_destination_policy" {
   default     = false
 }
 
+variable "attach_deny_incorrect_encryption_headers" {
+  description = "Controls if S3 bucket should deny incorrect encryption headers policy attached."
+  type        = bool
+  default     = false
+}
+
+variable "attach_deny_unencrypted_object_uploads" {
+  description = "Controls if S3 bucket should deny unencrypted object uploads policy attached."
+  type        = bool
+  default     = false
+}
+
 variable "bucket" {
   description = "(Optional, Forces new resource) The name of the bucket. If omitted, Terraform will assign a random, unique name."
   type        = string

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -13,6 +13,8 @@ module "wrapper" {
   attach_public_policy                       = try(each.value.attach_public_policy, var.defaults.attach_public_policy, true)
   attach_inventory_destination_policy        = try(each.value.attach_inventory_destination_policy, var.defaults.attach_inventory_destination_policy, false)
   attach_analytics_destination_policy        = try(each.value.attach_analytics_destination_policy, var.defaults.attach_analytics_destination_policy, false)
+  attach_deny_incorrect_encryption_headers   = try(each.value.attach_deny_incorrect_encryption_headers, var.defaults.attach_deny_incorrect_encryption_headers, false)
+  attach_deny_unencrypted_object_uploads     = try(each.value.attach_deny_unencrypted_object_uploads, var.defaults.attach_deny_unencrypted_object_uploads, false)
   bucket                                     = try(each.value.bucket, var.defaults.bucket, null)
   bucket_prefix                              = try(each.value.bucket_prefix, var.defaults.bucket_prefix, null)
   acl                                        = try(each.value.acl, var.defaults.acl, null)


### PR DESCRIPTION
## Description
Adds attachments for deny unencrypted object uploads and incorrect encryption headers. 
Fixes https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/issues/233

## Motivation and Context
Fixes https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/issues/233

## Breaking Changes
No.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as it's written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
