### PR TITLE
feat: Stop requiring `s3:ListAllMyBuckets` IAM permission unless needed (for bucket ACL)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,8 @@
 data "aws_region" "current" {}
 
-data "aws_canonical_user_id" "this" {}
+data "aws_canonical_user_id" "this" {
+  count = local.create_bucket && ((var.acl != null && var.acl != "null") || length(local.grants) > 0) ? 1 : 0
+}
 
 data "aws_caller_identity" "current" {}
 
@@ -67,7 +69,7 @@ resource "aws_s3_bucket_acl" "this" {
       }
 
       owner {
-        id           = try(var.owner["id"], data.aws_canonical_user_id.this.id)
+        id           = try(var.owner["id"], data.aws_canonical_user_id.this[0].id)
         display_name = try(var.owner["display_name"], null)
       }
     }

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 data "aws_region" "current" {}
 
 data "aws_canonical_user_id" "this" {
-  count = local.create_bucket && ((var.acl != null && var.acl != "null") || length(local.grants) > 0) ? 1 : 0
+  count = local.create_bucket && local.create_bucket_acl && try(var.owner["id"], null) == null ? 1 : 0
 }
 
 data "aws_caller_identity" "current" {}
@@ -9,6 +9,8 @@ data "aws_caller_identity" "current" {}
 data "aws_partition" "current" {}
 locals {
   create_bucket = var.create_bucket && var.putin_khuylo
+
+  create_bucket_acl = (var.acl != null && var.acl != "null") || length(local.grants) > 0
 
   attach_policy = var.attach_require_latest_tls_policy || var.attach_elb_log_delivery_policy || var.attach_lb_log_delivery_policy || var.attach_deny_insecure_transport_policy || var.attach_inventory_destination_policy || var.attach_deny_incorrect_encryption_headers || var.attach_deny_incorrect_kms_key_sse || var.attach_deny_unencrypted_object_uploads || var.attach_policy
 
@@ -41,7 +43,7 @@ resource "aws_s3_bucket_logging" "this" {
 }
 
 resource "aws_s3_bucket_acl" "this" {
-  count = local.create_bucket && ((var.acl != null && var.acl != "null") || length(local.grants) > 0) ? 1 : 0
+  count = local.create_bucket && local.create_bucket_acl ? 1 : 0
 
   bucket                = aws_s3_bucket.this[0].id
   expected_bucket_owner = var.expected_bucket_owner


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

This skips executing the `data.aws_canonical_user_id.this` data source unless it is actually needed.

The data source is only needed when the `aws_s3_bucket_acl.this` resource needs to be created **and** the `var.owner["id"]` value isn't available.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

As per [the `data.aws_canonical_user_id` documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/canonical_user_id), this data source requires the `s3:ListAllMyBuckets` IAM permission. Note that this permission isn't required by anything else in this module.

When the data source isn't needed, then by the [principle of least privilege](https://en.wikipedia.org/wiki/Principle_of_least_privilege), we shouldn't require the `s3:ListAllMyBuckets` permission.

This additional permission is particularly obvious when [migrating](https://developer.hashicorp.com/terraform/tutorials/configuration-language/move-config) existing `aws_s3_*` resources into this module.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

Not a breaking change:

 - the module interface (i.e. input and output variables) has not changed; and,
 - for existing use cases where the IAM entity already has the `s3:ListAllMyBuckets` permission, the module will continue to behave as before except simply skip the `ListBuckets` S3 API calls.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s) - _No interface changes._
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
