### PR TITLE
#242-S3 bucket ACL for: AccessDenied

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -277,7 +277,7 @@ variable "object_lock_enabled" {
 variable "block_public_acls" {
   description = "Whether Amazon S3 should block public ACLs for this bucket."
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "block_public_policy" {


### PR DESCRIPTION
## Description
We are getting this access denied error due to the fact that we can not have -

Block public access (bucket settings) Block all public access = true
Access control list (ACL) Everyone (public access) = true