### PR TITLE
fix: Fixed creating S3 bucket ACL for: AccessDenied: Access Denied

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -277,7 +277,7 @@ variable "object_lock_enabled" {
 variable "block_public_acls" {
   description = "Whether Amazon S3 should block public ACLs for this bucket."
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "block_public_policy" {


### PR DESCRIPTION
## Description
closes #242 

## Motivation and Context
#242

## Breaking Changes
modify variable block_public_acls default value from true to false 

## How Has This Been Tested?
- I've cloned the repo and ran terraform apply which gave me same erorr. 
- modify the variable block_public_acls default value from true to false 
- ran terraform apply and it created the s3 bucket
