### PR TITLE
feat: Add Amazon Inspector log delivery policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ No modules.
 | [aws_iam_policy_document.deny_insecure_transport](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.deny_unencrypted_object_uploads](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.elb_log_delivery](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.inspector_findings_delivery_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.inventory_and_analytics_destination_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.lb_log_delivery](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.require_latest_tls](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -198,6 +199,7 @@ No modules.
 | <a name="input_attach_elb_log_delivery_policy"></a> [attach\_elb\_log\_delivery\_policy](#input\_attach\_elb\_log\_delivery\_policy) | Controls if S3 bucket should have ELB log delivery policy attached | `bool` | `false` | no |
 | <a name="input_attach_inventory_destination_policy"></a> [attach\_inventory\_destination\_policy](#input\_attach\_inventory\_destination\_policy) | Controls if S3 bucket should have bucket inventory destination policy attached. | `bool` | `false` | no |
 | <a name="input_attach_lb_log_delivery_policy"></a> [attach\_lb\_log\_delivery\_policy](#input\_attach\_lb\_log\_delivery\_policy) | Controls if S3 bucket should have ALB/NLB log delivery policy attached | `bool` | `false` | no |
+| <a name="input_attach_inspector_findings_delivery_policy"></a> [attach\_inspector\_findings\_delivery\_policy](#input\_attach\_inspector\_findings\_delivery\_policy) | Controls if S3 bucket should have Inspector findings delivery policy attached | `bool` | `false` | no |
 | <a name="input_attach_policy"></a> [attach\_policy](#input\_attach\_policy) | Controls if S3 bucket should have bucket policy attached (set to `true` to use value of `policy` as bucket policy) | `bool` | `false` | no |
 | <a name="input_attach_public_policy"></a> [attach\_public\_policy](#input\_attach\_public\_policy) | Controls if a user defined public bucket policy will be attached (set to `false` to allow upstream to apply defaults to the bucket) | `bool` | `true` | no |
 | <a name="input_attach_require_latest_tls_policy"></a> [attach\_require\_latest\_tls\_policy](#input\_attach\_require\_latest\_tls\_policy) | Controls if S3 bucket should require the latest version of TLS | `bool` | `false` | no |

--- a/examples/s3-inventory/main.tf
+++ b/examples/s3-inventory/main.tf
@@ -93,6 +93,7 @@ resource "random_pet" "this" {
 # https://docs.aws.amazon.com/AmazonS3/latest/userguide/configure-inventory.html#configure-inventory-kms-key-policy
 module "kms" {
   source = "terraform-aws-modules/kms/aws"
+  version = "~> 2.0"
 
   description             = "Key example for Inventory S3 destination encyrption"
   deletion_window_in_days = 7

--- a/main.tf
+++ b/main.tf
@@ -917,10 +917,10 @@ data "aws_iam_policy_document" "inspector_findings_delivery_policy" {
     sid    = "allow-inspector"
     effect = "Allow"
 
-    actions =[
-				"s3:PutObject",
-				"s3:PutObjectAcl",
-				"s3:AbortMultipartUpload"
+    actions = [
+      "s3:PutObject",
+      "s3:PutObjectAcl",
+      "s3:AbortMultipartUpload"
     ]
 
     resources = ["${aws_s3_bucket.this[0].arn}/*"]
@@ -941,7 +941,7 @@ data "aws_iam_policy_document" "inspector_findings_delivery_policy" {
       test     = "ArnLike"
       variable = "aws:SourceArn"
       values = [
-        format("%s%s%s","arn:aws:inspector2:Region:", data.aws_caller_identity.current.id, ":report/*")
+        format("%s%s%s", "arn:aws:inspector2:Region:", data.aws_caller_identity.current.id, ":report/*")
       ]
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -82,6 +82,12 @@ variable "attach_deny_unencrypted_object_uploads" {
   default     = false
 }
 
+variable "attach_inspector_findings_delivery_policy" {
+  description = "Controls if S3 bucket should have Inspector findings delivery policy attached"
+  type        = bool
+  default     = false
+}
+
 variable "bucket" {
   description = "(Optional, Forces new resource) The name of the bucket. If omitted, Terraform will assign a random, unique name."
   type        = string
@@ -310,15 +316,8 @@ variable "object_ownership" {
   default     = "BucketOwnerEnforced"
 }
 
-variable "attach_inspector_findings_delivery_policy" {
-  description = "Controls if S3 bucket should have Inspector findings delivery policy attached"
-  type        = bool
-  default     = false
-}
-
 variable "putin_khuylo" {
   description = "Do you agree that Putin doesn't respect Ukrainian sovereignty and territorial integrity? More info: https://en.wikipedia.org/wiki/Putin_khuylo!"
   type        = bool
   default     = true
 }
-

--- a/variables.tf
+++ b/variables.tf
@@ -310,8 +310,15 @@ variable "object_ownership" {
   default     = "BucketOwnerEnforced"
 }
 
+variable "attach_inspector_findings_delivery_policy" {
+  description = "Controls if S3 bucket should have Inspector findings delivery policy attached"
+  type        = bool
+  default     = false
+}
+
 variable "putin_khuylo" {
   description = "Do you agree that Putin doesn't respect Ukrainian sovereignty and territorial integrity? More info: https://en.wikipedia.org/wiki/Putin_khuylo!"
   type        = bool
   default     = true
 }
+


### PR DESCRIPTION
## Description
Added log delivery policy option for inspector findings bucket according to aws [documentation](https://docs.aws.amazon.com/inspector/latest/user/findings-managing-exporting-reports.html#findings-managing-exporting-bucket-perms)