### PR TITLE
fix: Remove ACL in analytics, inventory, and replication examples

### DIFF
--- a/examples/s3-analytics/main.tf
+++ b/examples/s3-analytics/main.tf
@@ -24,7 +24,6 @@ module "analytics_configuration_bucket" {
   attach_analytics_destination_policy = true
   attach_policy                       = true
   analytics_self_source_destination   = true
-  acl                                 = "private" # "acl" conflicts with "grant" and "owner"
 
   versioning = {
     status     = true
@@ -77,7 +76,6 @@ module "analytics_destination_bucket" {
   source = "../../"
 
   bucket                              = "analytics-destination-${random_pet.this.id}"
-  acl                                 = "private" # "acl" conflicts with "grant" and "owner"
   force_destroy                       = true
   attach_policy                       = true
   attach_analytics_destination_policy = true
@@ -92,7 +90,6 @@ module "inventory_source_bucket" {
   bucket = "inventory-source-${random_pet.this.id}"
 
   force_destroy = true
-  acl           = "private" # "acl" conflicts with "grant" and "owner"
 
   inventory_configuration = {
     destination_other = {
@@ -115,7 +112,6 @@ module "analytics_and_inventory_destination_bucket" {
   source = "../../"
 
   bucket        = "analytics-and-inventory-destination-${random_pet.this.id}"
-  acl           = "private" # "acl" conflicts with "grant" and "owner"
   force_destroy = true
   attach_policy = true
 

--- a/examples/s3-inventory/main.tf
+++ b/examples/s3-inventory/main.tf
@@ -24,7 +24,6 @@ module "multi_inventory_configurations_bucket" {
   attach_policy                       = true
   attach_inventory_destination_policy = true
   inventory_self_source_destination   = true
-  acl                                 = "private" # "acl" conflicts with "grant" and "owner"
 
   versioning = {
     status     = true
@@ -137,7 +136,6 @@ module "inventory_destination_bucket" {
   source = "../../"
 
   bucket                              = "inventory-destination-${random_pet.this.id}"
-  acl                                 = "private" # "acl" conflicts with "grant" and "owner"
   force_destroy                       = true
   attach_policy                       = true
   attach_inventory_destination_policy = true
@@ -149,6 +147,5 @@ module "inventory_source_bucket" {
   source = "../../"
 
   bucket        = "inventory-source-${random_pet.this.id}"
-  acl           = "private" # "acl" conflicts with "grant" and "owner"
   force_destroy = true
 }

--- a/examples/s3-replication/main.tf
+++ b/examples/s3-replication/main.tf
@@ -16,7 +16,6 @@ provider "aws" {
   skip_metadata_api_check     = true
   skip_region_validation      = true
   skip_credentials_validation = true
-  skip_requesting_account_id  = true
 }
 
 locals {
@@ -47,7 +46,6 @@ module "replica_bucket" {
   }
 
   bucket = local.destination_bucket_name
-  acl    = "private"
 
   versioning = {
     enabled = true
@@ -58,7 +56,6 @@ module "s3_bucket" {
   source = "../../"
 
   bucket = local.bucket_name
-  acl    = "private"
 
   versioning = {
     enabled = true


### PR DESCRIPTION
## Description
Some examples still have `acl` being set with default object ownership getting created with `BucketOwnerEnforced` which doesn't support ACLs. This just removes `acl`.

## Motivation and Context
Fixes examples which produce error currently:
```
╷
│ Error: creating S3 Bucket (analytics-and-inventory-destination-fresh-kitten) ACL: operation error S3: PutBucketAcl, https response error StatusCode: 400, RequestID: <>, HostID: <>, api error AccessControlListNotSupported: The bucket does not allow ACLs
│ 
│   with module.analytics_and_inventory_destination_bucket.aws_s3_bucket_acl.this[0],
│   on ../../main.tf line 66, in resource "aws_s3_bucket_acl" "this":
│   66: resource "aws_s3_bucket_acl" "this" {
│ 
╵
```

## Breaking Changes
No.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
