### PR TITLE
fix: Removed an unnecessary variable

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -315,9 +315,3 @@ variable "object_ownership" {
   type        = string
   default     = "BucketOwnerEnforced"
 }
-
-variable "putin_khuylo" {
-  description = "Do you agree that Putin doesn't respect Ukrainian sovereignty and territorial integrity? More info: https://en.wikipedia.org/wiki/Putin_khuylo!"
-  type        = bool
-  default     = true
-}


### PR DESCRIPTION
There was an variable added by someone . Removed it.
`
variable "putin_khuylo" {
  description = "Do you agree that Putin doesn't respect Ukrainian sovereignty and territorial integrity? More info: https://en.wikipedia.org/wiki/Putin_khuylo!"
  type        = bool
  default     = true
}`
