### PR TITLE
feat: Add variable create_lambda_permission in notification module

### DIFF
--- a/modules/notification/README.md
+++ b/modules/notification/README.md
@@ -40,7 +40,7 @@ No modules.
 | <a name="input_bucket"></a> [bucket](#input\_bucket) | Name of S3 bucket to use | `string` | `""` | no |
 | <a name="input_bucket_arn"></a> [bucket\_arn](#input\_bucket\_arn) | ARN of S3 bucket to use in policies | `string` | `null` | no |
 | <a name="input_create"></a> [create](#input\_create) | Whether to create this resource or not? | `bool` | `true` | no |
-| <a name="input_create_lambda_policy"></a> [create\_lambda\_policy](#input\_create\_lambda\_policy) | Whether to create a policy for Lambda permissions or not? | `bool` | `true` | no |
+| <a name="input_create_lambda_permission"></a> [create\_lambda\_permission](#input\_create\_lambda\_permission) | Whether to create Lambda permissions or not? | `bool` | `true` | no |
 | <a name="input_create_sns_policy"></a> [create\_sns\_policy](#input\_create\_sns\_policy) | Whether to create a policy for SNS permissions or not? | `bool` | `true` | no |
 | <a name="input_create_sqs_policy"></a> [create\_sqs\_policy](#input\_create\_sqs\_policy) | Whether to create a policy for SQS permissions or not? | `bool` | `true` | no |
 | <a name="input_eventbridge"></a> [eventbridge](#input\_eventbridge) | Whether to enable Amazon EventBridge notifications | `bool` | `null` | no |

--- a/modules/notification/README.md
+++ b/modules/notification/README.md
@@ -40,6 +40,7 @@ No modules.
 | <a name="input_bucket"></a> [bucket](#input\_bucket) | Name of S3 bucket to use | `string` | `""` | no |
 | <a name="input_bucket_arn"></a> [bucket\_arn](#input\_bucket\_arn) | ARN of S3 bucket to use in policies | `string` | `null` | no |
 | <a name="input_create"></a> [create](#input\_create) | Whether to create this resource or not? | `bool` | `true` | no |
+| <a name="input_create_lambda_policy"></a> [create\_lambda\_policy](#input\_create\_lambda\_policy) | Whether to create a policy for Lambda permissions or not? | `bool` | `true` | no |
 | <a name="input_create_sns_policy"></a> [create\_sns\_policy](#input\_create\_sns\_policy) | Whether to create a policy for SNS permissions or not? | `bool` | `true` | no |
 | <a name="input_create_sqs_policy"></a> [create\_sqs\_policy](#input\_create\_sqs\_policy) | Whether to create a policy for SQS permissions or not? | `bool` | `true` | no |
 | <a name="input_eventbridge"></a> [eventbridge](#input\_eventbridge) | Whether to enable Amazon EventBridge notifications | `bool` | `null` | no |

--- a/modules/notification/main.tf
+++ b/modules/notification/main.tf
@@ -60,7 +60,7 @@ resource "aws_s3_bucket_notification" "this" {
 
 # Lambda
 resource "aws_lambda_permission" "allow" {
-  for_each = var.lambda_notifications
+  for_each = { for k, v in var.lambda_notifications : k => v if var.create_lambda_policy }
 
   statement_id_prefix = "AllowLambdaS3BucketNotification-"
   action              = "lambda:InvokeFunction"

--- a/modules/notification/main.tf
+++ b/modules/notification/main.tf
@@ -60,7 +60,7 @@ resource "aws_s3_bucket_notification" "this" {
 
 # Lambda
 resource "aws_lambda_permission" "allow" {
-  for_each = { for k, v in var.lambda_notifications : k => v if var.create_lambda_policy }
+  for_each = { for k, v in var.lambda_notifications : k => v if var.create_lambda_permission }
 
   statement_id_prefix = "AllowLambdaS3BucketNotification-"
   action              = "lambda:InvokeFunction"

--- a/modules/notification/variables.tf
+++ b/modules/notification/variables.tf
@@ -16,6 +16,12 @@ variable "create_sqs_policy" {
   default     = true
 }
 
+variable "create_lambda_policy" {
+  description = "Whether to create a policy for Lambda permissions or not?"
+  type        = bool
+  default     = true
+}
+
 variable "bucket" {
   description = "Name of S3 bucket to use"
   type        = string

--- a/modules/notification/variables.tf
+++ b/modules/notification/variables.tf
@@ -16,8 +16,8 @@ variable "create_sqs_policy" {
   default     = true
 }
 
-variable "create_lambda_policy" {
-  description = "Whether to create a policy for Lambda permissions or not?"
+variable "create_lambda_permission" {
+  description = "Whether to create Lambda permissions or not?"
   type        = bool
   default     = true
 }

--- a/wrappers/notification/main.tf
+++ b/wrappers/notification/main.tf
@@ -3,14 +3,14 @@ module "wrapper" {
 
   for_each = var.items
 
-  bucket               = try(each.value.bucket, var.defaults.bucket, "")
-  bucket_arn           = try(each.value.bucket_arn, var.defaults.bucket_arn, null)
-  create               = try(each.value.create, var.defaults.create, true)
-  create_lambda_policy = try(each.value.create_lambda_policy, var.defaults.create_lambda_policy, true)
-  create_sns_policy    = try(each.value.create_sns_policy, var.defaults.create_sns_policy, true)
-  create_sqs_policy    = try(each.value.create_sqs_policy, var.defaults.create_sqs_policy, true)
-  eventbridge          = try(each.value.eventbridge, var.defaults.eventbridge, null)
-  lambda_notifications = try(each.value.lambda_notifications, var.defaults.lambda_notifications, {})
-  sns_notifications    = try(each.value.sns_notifications, var.defaults.sns_notifications, {})
-  sqs_notifications    = try(each.value.sqs_notifications, var.defaults.sqs_notifications, {})
+  bucket                   = try(each.value.bucket, var.defaults.bucket, "")
+  bucket_arn               = try(each.value.bucket_arn, var.defaults.bucket_arn, null)
+  create                   = try(each.value.create, var.defaults.create, true)
+  create_lambda_permission = try(each.value.create_lambda_permission, var.defaults.create_lambda_permission, true)
+  create_sns_policy        = try(each.value.create_sns_policy, var.defaults.create_sns_policy, true)
+  create_sqs_policy        = try(each.value.create_sqs_policy, var.defaults.create_sqs_policy, true)
+  eventbridge              = try(each.value.eventbridge, var.defaults.eventbridge, null)
+  lambda_notifications     = try(each.value.lambda_notifications, var.defaults.lambda_notifications, {})
+  sns_notifications        = try(each.value.sns_notifications, var.defaults.sns_notifications, {})
+  sqs_notifications        = try(each.value.sqs_notifications, var.defaults.sqs_notifications, {})
 }

--- a/wrappers/notification/main.tf
+++ b/wrappers/notification/main.tf
@@ -6,6 +6,7 @@ module "wrapper" {
   bucket               = try(each.value.bucket, var.defaults.bucket, "")
   bucket_arn           = try(each.value.bucket_arn, var.defaults.bucket_arn, null)
   create               = try(each.value.create, var.defaults.create, true)
+  create_lambda_policy = try(each.value.create_lambda_policy, var.defaults.create_lambda_policy, true)
   create_sns_policy    = try(each.value.create_sns_policy, var.defaults.create_sns_policy, true)
   create_sqs_policy    = try(each.value.create_sqs_policy, var.defaults.create_sqs_policy, true)
   eventbridge          = try(each.value.eventbridge, var.defaults.eventbridge, null)


### PR DESCRIPTION
## Description
In the Notification module create a new variable a new `create_lambda_policy` that functions similar to `create_sqs_policy` and `create_sns_policy`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I define and manage my Lambda Policy separate from the Terraform where I manage my S3 Notifications. I don't want this module to force me to manage the Lambda policy here.
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #301 

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
I think that migrating `aws_lambda_permission.allow` from a single to a `count` this will cause the Resource to be recreated.
This can be avoided by performing [`terraform state mv`](https://developer.hashicorp.com/terraform/cli/commands/state/mv)
<!-- If so, please provide an explanation why it is necessary. -->
There are 3 types of notifications, and this change brings Lambda in line with SQS and SNS that support `create_sqs_policy` and `create_sns_policy`

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
