### PR TITLE
feat: Allow for policy creation for externally created s3 buckets

### DIFF
--- a/examples/s3-policy/README.md
+++ b/examples/s3-policy/README.md
@@ -1,0 +1,58 @@
+# Complete S3 bucket with most of supported features enabled
+
+This configuration allows for deployment of a S3 Bucket Policy independent of S3 Bucket creation
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Note that this example may create resources which cost money. Run `terraform destroy` when you don't need these resources.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.70 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.70 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | ../../ | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
+| [aws_iam_policy_document.bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_s3_bucket_arn"></a> [s3\_bucket\_arn](#output\_s3\_bucket\_arn) | The ARN of the bucket. Will be of format arn:aws:s3:::bucketname. |
+| <a name="output_s3_bucket_id"></a> [s3\_bucket\_id](#output\_s3\_bucket\_id) | The name of the bucket. |
+| <a name="output_s3_bucket_policy"></a> [s3\_bucket\_policy](#output\_s3\_bucket\_policy) | The policy of the bucket, if the bucket is configured with a policy. If not, this will be an empty string. |
+<!-- END_TF_DOCS -->

--- a/examples/s3-policy/main.tf
+++ b/examples/s3-policy/main.tf
@@ -1,0 +1,82 @@
+provider "aws" {
+  region = local.region
+
+  # Improve speed by skipping unnecessary checks
+  skip_metadata_api_check     = true
+  skip_region_validation      = true
+  skip_credentials_validation = true
+}
+
+locals {
+  bucket_name    = "s3-bucket-${random_pet.this.id}"
+  region         = "eu-west-1"
+  create_bucket  = false
+  attach_policy  = true
+  force_destroy  = true
+  versioning     = true
+  enable_logging = true
+  acl           = "private"
+}
+
+resource "random_pet" "this" {
+  length = 2
+}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_canonical_user_id" "current" {}
+
+resource "aws_iam_role" "this" {
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+# S3 Bucket Policy Document
+data "aws_iam_policy_document" "bucket_policy" {
+  statement {
+    principals {
+      type        = "AWS"
+      identifiers = [aws_iam_role.this.arn]
+    }
+
+    actions = [
+      "s3:ListBucket",
+    ]
+
+    resources = [
+      "arn:aws:s3:::${local.bucket_name}",
+    ]
+  }
+}
+
+# S3 Bucket Module
+module "s3_bucket" {
+  source = "../../"
+
+  create_bucket = local.create_bucket
+  bucket        = local.bucket_name
+
+  attach_policy = local.attach_policy
+  policy        = data.aws_iam_policy_document.bucket_policy.json
+
+  force_destroy = local.force_destroy
+  versioning    = { enabled = local.versioning }
+
+  tags = {
+    Environment = "Dev"
+    ManagedBy   = "Terraform"
+  }
+}

--- a/examples/s3-policy/outputs.tf
+++ b/examples/s3-policy/outputs.tf
@@ -1,0 +1,14 @@
+output "bucket_id" {
+  description = "The ID of the existing S3 bucket"
+  value       = module.s3_bucket.s3_bucket_id
+}
+
+output "bucket_arn" {
+  description = "The ARN of the existing S3 bucket"
+  value       = module.s3_bucket.s3_bucket_arn
+}
+
+output "policy" {
+  description = "The applied bucket policy"
+  value       = module.s3_bucket.s3_bucket_policy
+}

--- a/examples/s3-policy/versions.tf
+++ b/examples/s3-policy/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.70"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 2.0"
+    }
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -534,13 +534,13 @@ resource "aws_s3_bucket_replication_configuration" "this" {
 }
 
 resource "aws_s3_bucket_policy" "this" {
-  count = local.create_bucket && local.attach_policy ? 1 : 0
+  count = local.attach_policy ? 1 : 0
 
   # Chain resources (s3_bucket -> s3_bucket_public_access_block -> s3_bucket_policy )
   # to prevent "A conflicting conditional operation is currently in progress against this resource."
   # Ref: https://github.com/hashicorp/terraform-provider-aws/issues/7628
 
-  bucket = aws_s3_bucket.this[0].id
+  bucket = local.create_bucket ? aws_s3_bucket.this[0].id : var.bucket
   policy = data.aws_iam_policy_document.combined[0].json
 
   depends_on = [
@@ -549,7 +549,7 @@ resource "aws_s3_bucket_policy" "this" {
 }
 
 data "aws_iam_policy_document" "combined" {
-  count = local.create_bucket && local.attach_policy ? 1 : 0
+  count = local.attach_policy ? 1 : 0
 
   source_policy_documents = compact([
     var.attach_elb_log_delivery_policy ? data.aws_iam_policy_document.elb_log_delivery[0].json : "",


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Changes to the count which controls whether policy will be created/updated so that policies can be independently created for externally created s3 buckets, this is particularly useful if you use the module to create a bucket then create a cloudfront to serve the bucket and have to make adjustments to the policy after the bucket has been created as described in #305 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Experienced the problem first hand and also resolves #305 

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
This shouldn't break backwards compatibility

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
