### PR TITLE
docs: Remove acl setting from ALB/NLB example in readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ module "s3_bucket_for_logs" {
   source = "terraform-aws-modules/s3-bucket/aws"
 
   bucket = "my-s3-bucket-for-logs"
-  acl    = "log-delivery-write"
 
   # Allow deletion of non-empty bucket
   force_destroy = true


### PR DESCRIPTION
## Description
remove `acl` setting from ALB/NLB example in readme file

## Motivation and Context
The [Terraform AWS Provider Version 4 Upgrade Guide](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-4-upgrade#acl-argument) states that the `acl` argument should be removed from the `aws_s3_bucket` resource

## Breaking Changes
No. This is a change to a readme file

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
    n/a change is only to a readme file
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
    n/a change is only to a readme file
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
    n/a change is only to a readme file
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
