### PR TITLE
fix: Include `aws_s3_directory_bucket` ID in `s3_bucket_id` output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 output "s3_bucket_id" {
   description = "The name of the bucket."
-  value       = try(aws_s3_bucket_policy.this[0].id, aws_s3_bucket.this[0].id, "")
+  value       = try(aws_s3_bucket.this[0].id, aws_s3_directory_bucket.this[0].bucket, "")
 }
 
 output "s3_bucket_arn" {


### PR DESCRIPTION
## Description
Use the id of the s3 bucket or the directory bucket instead of the policy. 

## Motivation and Context
When attaching a policy after the bucket creation, any resource dependent on the output `s3_bucket_id` will show needing modified and possibly destroyed and recreated. This change will use the bucket resources directly to determine the bucket id instead of reading the policy first. 

## Breaking Changes


## How Has This Been Tested?
- [ No Changes ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ X ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ X ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
