### PR TITLE
feat: S3 table and table bucket CMK encryption support

### DIFF
--- a/examples/table-bucket/README.md
+++ b/examples/table-bucket/README.md
@@ -20,20 +20,21 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.83 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.98 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.83 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.98 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_kms"></a> [kms](#module\_kms) | terraform-aws-modules/kms/aws | ~> 2.0 |
 | <a name="module_table_bucket"></a> [table\_bucket](#module\_table\_bucket) | ../../modules/table-bucket | n/a |
 
 ## Resources
@@ -43,6 +44,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | [aws_s3tables_namespace.namespace](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3tables_namespace) | resource |
 | [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |
 | [aws_caller_identity.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_region.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 

--- a/examples/table-bucket/main.tf
+++ b/examples/table-bucket/main.tf
@@ -13,10 +13,17 @@ locals {
 
 data "aws_caller_identity" "this" {}
 
+data "aws_region" "this" {}
+
 module "table_bucket" {
   source = "../../modules/table-bucket"
 
   table_bucket_name = local.bucket_name
+
+  encryption_configuration = {
+    kms_key_arn   = module.kms.key_arn
+    sse_algorithm = "aws:kms"
+  }
 
   maintenance_configuration = {
     iceberg_unreferenced_file_removal = {
@@ -48,6 +55,11 @@ module "table_bucket" {
     table1 = {
       format    = "ICEBERG"
       namespace = aws_s3tables_namespace.namespace.namespace
+
+      encryption_configuration = {
+        kms_key_arn   = module.kms.key_arn
+        sse_algorithm = "aws:kms"
+      }
 
       maintenance_configuration = {
         iceberg_compaction = {
@@ -102,4 +114,47 @@ resource "random_pet" "this" {
 resource "aws_s3tables_namespace" "namespace" {
   namespace        = "example_namespace"
   table_bucket_arn = module.table_bucket.s3_table_bucket_arn
+}
+
+module "kms" {
+  source  = "terraform-aws-modules/kms/aws"
+  version = "~> 2.0"
+
+  description             = "Key example for s3 table buckets"
+  deletion_window_in_days = 7
+
+  key_statements = [
+    {
+      sid = "s3TablesMaintenancePolicy"
+      actions = [
+        "kms:GenerateDataKey",
+        "kms:Decrypt"
+      ]
+      resources = ["*"]
+
+      principals = [
+        {
+          type        = "Service"
+          identifiers = ["maintenance.s3tables.amazonaws.com"]
+        }
+      ]
+
+      conditions = [
+        {
+          test     = "StringEquals"
+          variable = "aws:SourceAccount"
+          values = [
+            data.aws_caller_identity.this.id,
+          ]
+        },
+        {
+          test     = "StringLike"
+          variable = "kms:EncryptionContext:aws:s3:arn"
+          values = [
+            "arn:aws:s3tables:${data.aws_region.this.name}:${data.aws_caller_identity.this.account_id}:bucket/${local.bucket_name}/table/*"
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/examples/table-bucket/main.tf
+++ b/examples/table-bucket/main.tf
@@ -123,6 +123,7 @@ module "kms" {
   description             = "Key example for s3 table buckets"
   deletion_window_in_days = 7
 
+  # https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables-kms-permissions.html
   key_statements = [
     {
       sid = "s3TablesMaintenancePolicy"

--- a/examples/table-bucket/versions.tf
+++ b/examples/table-bucket/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.83"
+      version = ">= 5.98"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/table-bucket/README.md
+++ b/modules/table-bucket/README.md
@@ -8,13 +8,13 @@ Creates S3 Table Bucket and Tables with various configurations.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.83 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.98 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.83 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.98 |
 
 ## Modules
 
@@ -37,6 +37,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_create"></a> [create](#input\_create) | Whether to create s3 table resources | `bool` | `true` | no |
 | <a name="input_create_table_bucket_policy"></a> [create\_table\_bucket\_policy](#input\_create\_table\_bucket\_policy) | Whether to create s3 table bucket policy | `bool` | `false` | no |
+| <a name="input_encryption_configuration"></a> [encryption\_configuration](#input\_encryption\_configuration) | Map of encryption configurations | `any` | `null` | no |
 | <a name="input_maintenance_configuration"></a> [maintenance\_configuration](#input\_maintenance\_configuration) | Map of table bucket maintenance configurations | `any` | `{}` | no |
 | <a name="input_table_bucket_name"></a> [table\_bucket\_name](#input\_table\_bucket\_name) | Name of the table bucket. Must be between 3 and 63 characters in length. Can consist of lowercase letters, numbers, and hyphens, and must begin and end with a lowercase letter or number | `string` | `null` | no |
 | <a name="input_table_bucket_override_policy_documents"></a> [table\_bucket\_override\_policy\_documents](#input\_table\_bucket\_override\_policy\_documents) | List of IAM policy documents that are merged together into the exported document. In merging, statements with non-blank `sid`s will override statements with the same `sid` | `list(string)` | `[]` | no |

--- a/modules/table-bucket/README.md
+++ b/modules/table-bucket/README.md
@@ -38,7 +38,7 @@ No modules.
 | <a name="input_create"></a> [create](#input\_create) | Whether to create s3 table resources | `bool` | `true` | no |
 | <a name="input_create_table_bucket_policy"></a> [create\_table\_bucket\_policy](#input\_create\_table\_bucket\_policy) | Whether to create s3 table bucket policy | `bool` | `false` | no |
 | <a name="input_encryption_configuration"></a> [encryption\_configuration](#input\_encryption\_configuration) | Map of encryption configurations | `any` | `null` | no |
-| <a name="input_maintenance_configuration"></a> [maintenance\_configuration](#input\_maintenance\_configuration) | Map of table bucket maintenance configurations | `any` | `{}` | no |
+| <a name="input_maintenance_configuration"></a> [maintenance\_configuration](#input\_maintenance\_configuration) | Map of table bucket maintenance configurations | `any` | `null` | no |
 | <a name="input_table_bucket_name"></a> [table\_bucket\_name](#input\_table\_bucket\_name) | Name of the table bucket. Must be between 3 and 63 characters in length. Can consist of lowercase letters, numbers, and hyphens, and must begin and end with a lowercase letter or number | `string` | `null` | no |
 | <a name="input_table_bucket_override_policy_documents"></a> [table\_bucket\_override\_policy\_documents](#input\_table\_bucket\_override\_policy\_documents) | List of IAM policy documents that are merged together into the exported document. In merging, statements with non-blank `sid`s will override statements with the same `sid` | `list(string)` | `[]` | no |
 | <a name="input_table_bucket_policy"></a> [table\_bucket\_policy](#input\_table\_bucket\_policy) | Amazon Web Services resource-based policy document in JSON format | `string` | `null` | no |

--- a/modules/table-bucket/main.tf
+++ b/modules/table-bucket/main.tf
@@ -2,6 +2,7 @@ resource "aws_s3tables_table_bucket" "this" {
   count = var.create ? 1 : 0
 
   name                      = var.table_bucket_name
+  encryption_configuration  = var.encryption_configuration
   maintenance_configuration = var.maintenance_configuration
 }
 
@@ -67,6 +68,7 @@ resource "aws_s3tables_table" "this" {
   name                      = try(each.value.table_name, each.key)
   namespace                 = each.value.namespace
   table_bucket_arn          = aws_s3tables_table_bucket.this[0].arn
+  encryption_configuration  = try(each.value.encryption_configuration, null)
   maintenance_configuration = try(each.value.maintenance_configuration, null)
 }
 

--- a/modules/table-bucket/variables.tf
+++ b/modules/table-bucket/variables.tf
@@ -10,6 +10,12 @@ variable "table_bucket_name" {
   default     = null
 }
 
+variable "encryption_configuration" {
+  description = "Map of encryption configurations"
+  type        = any
+  default     = null
+}
+
 variable "maintenance_configuration" {
   description = "Map of table bucket maintenance configurations"
   type        = any

--- a/modules/table-bucket/variables.tf
+++ b/modules/table-bucket/variables.tf
@@ -19,7 +19,7 @@ variable "encryption_configuration" {
 variable "maintenance_configuration" {
   description = "Map of table bucket maintenance configurations"
   type        = any
-  default     = {}
+  default     = null
 }
 
 variable "create_table_bucket_policy" {

--- a/modules/table-bucket/versions.tf
+++ b/modules/table-bucket/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.83"
+      version = ">= 5.98"
     }
   }
 }

--- a/wrappers/table-bucket/main.tf
+++ b/wrappers/table-bucket/main.tf
@@ -6,7 +6,7 @@ module "wrapper" {
   create                                 = try(each.value.create, var.defaults.create, true)
   create_table_bucket_policy             = try(each.value.create_table_bucket_policy, var.defaults.create_table_bucket_policy, false)
   encryption_configuration               = try(each.value.encryption_configuration, var.defaults.encryption_configuration, null)
-  maintenance_configuration              = try(each.value.maintenance_configuration, var.defaults.maintenance_configuration, {})
+  maintenance_configuration              = try(each.value.maintenance_configuration, var.defaults.maintenance_configuration, null)
   table_bucket_name                      = try(each.value.table_bucket_name, var.defaults.table_bucket_name, null)
   table_bucket_override_policy_documents = try(each.value.table_bucket_override_policy_documents, var.defaults.table_bucket_override_policy_documents, [])
   table_bucket_policy                    = try(each.value.table_bucket_policy, var.defaults.table_bucket_policy, null)

--- a/wrappers/table-bucket/main.tf
+++ b/wrappers/table-bucket/main.tf
@@ -5,6 +5,7 @@ module "wrapper" {
 
   create                                 = try(each.value.create, var.defaults.create, true)
   create_table_bucket_policy             = try(each.value.create_table_bucket_policy, var.defaults.create_table_bucket_policy, false)
+  encryption_configuration               = try(each.value.encryption_configuration, var.defaults.encryption_configuration, null)
   maintenance_configuration              = try(each.value.maintenance_configuration, var.defaults.maintenance_configuration, {})
   table_bucket_name                      = try(each.value.table_bucket_name, var.defaults.table_bucket_name, null)
   table_bucket_override_policy_documents = try(each.value.table_bucket_override_policy_documents, var.defaults.table_bucket_override_policy_documents, [])

--- a/wrappers/table-bucket/versions.tf
+++ b/wrappers/table-bucket/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.83"
+      version = ">= 5.98"
     }
   }
 }


### PR DESCRIPTION
## Description
Add support for table bucket and table CMK encryption. 
Also fix default value of `maintenance_configuration` to allow for passing no configuration. 

## Motivation and Context
https://github.com/hashicorp/terraform-provider-aws/pull/42356

## Breaking Changes
No.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
