### PR TITLE
feat!: add support for AWS provider 6.0.0 with resolving deprecated aws_region warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,13 +152,13 @@ Users of Terragrunt can achieve similar results by using modules provided in the
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.83 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.83 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
 
 ## Modules
 

--- a/main.tf
+++ b/main.tf
@@ -620,7 +620,7 @@ data "aws_iam_policy_document" "elb_log_delivery" {
 
   # Policy for AWS Regions created before August 2022 (e.g. US East (N. Virginia), Asia Pacific (Singapore), Asia Pacific (Sydney), Asia Pacific (Tokyo), Europe (Ireland))
   dynamic "statement" {
-    for_each = { for k, v in local.elb_service_accounts : k => v if k == data.aws_region.current.name }
+    for_each = { for k, v in local.elb_service_accounts : k => v if k == data.aws_region.current.region }
 
     content {
       sid = format("ELBRegion%s", title(statement.key))
@@ -854,7 +854,7 @@ data "aws_iam_policy_document" "waf_log_delivery" {
 
     condition {
       test     = "ArnLike"
-      values   = ["arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.id}:*"]
+      values   = ["arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.id}:*"]
       variable = "aws:SourceArn"
     }
   }
@@ -885,7 +885,7 @@ data "aws_iam_policy_document" "waf_log_delivery" {
 
     condition {
       test     = "ArnLike"
-      values   = ["arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.id}:*"]
+      values   = ["arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.id}:*"]
       variable = "aws:SourceArn"
     }
   }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.83"
+      version = ">= 6.0.0"
     }
   }
 }

--- a/wrappers/versions.tf
+++ b/wrappers/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.83"
+      version = ">= 6.0.0"
     }
   }
 }


### PR DESCRIPTION
## Description
Add support for AWS provider 6.0.0 with resolving deprecated aws_region warnings

## Motivation and Context
Adding support for newest AWS provider

## Breaking Changes
Yes, the data source `aws_region` is replacing the `name` property with `region`

## How Has This Been Tested?

I used the following code to validate the module changes:

```
locals {
  s3_tf_state_bucket_name = "chose-your-own-bucket-name"
}

module "terraform_state" {
  source  = "github.com/mm-chia/terraform-aws-s3-bucket.git?ref=aws_provider_6.0.0"

  bucket = local.s3_tf_state_bucket_name

  block_public_acls                     = true
  ignore_public_acls                    = true
  block_public_policy                   = true
  restrict_public_buckets               = true
  attach_deny_insecure_transport_policy = true
  attach_require_latest_tls_policy      = true

  versioning = {
    enabled = true
  }
}
```

I ran:
- terraform init
- terraform plan
And checked that there are no more warnings related to deprecated `aws_region` data source.
These are the warnings that may show up, if not making the changes I made in `main.tf`:
```
│ Warning: Deprecated attribute
│
│   on .terraform/modules/terraform_state/main.tf line 888, in data "aws_iam_policy_document" "waf_log_delivery":
│  888:       values   = ["arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.id}:*"]
│
│ The attribute "name" is deprecated. Refer to the provider documentation for details.
```