### PR TITLE
fix: updated data.region.current.name reference

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -620,7 +620,7 @@ data "aws_iam_policy_document" "elb_log_delivery" {
 
   # Policy for AWS Regions created before August 2022 (e.g. US East (N. Virginia), Asia Pacific (Singapore), Asia Pacific (Sydney), Asia Pacific (Tokyo), Europe (Ireland))
   dynamic "statement" {
-    for_each = { for k, v in local.elb_service_accounts : k => v if k == data.aws_region.current.name }
+    for_each = { for k, v in local.elb_service_accounts : k => v if k == data.aws_region.current.id }
 
     content {
       sid = format("ELBRegion%s", title(statement.key))
@@ -854,7 +854,7 @@ data "aws_iam_policy_document" "waf_log_delivery" {
 
     condition {
       test     = "ArnLike"
-      values   = ["arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.id}:*"]
+      values   = ["arn:aws:logs:${data.aws_region.current.id}:${data.aws_caller_identity.current.id}:*"]
       variable = "aws:SourceArn"
     }
   }
@@ -885,7 +885,7 @@ data "aws_iam_policy_document" "waf_log_delivery" {
 
     condition {
       test     = "ArnLike"
-      values   = ["arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.id}:*"]
+      values   = ["arn:aws:logs:${data.aws_region.current.id}:${data.aws_caller_identity.current.id}:*"]
       variable = "aws:SourceArn"
     }
   }


### PR DESCRIPTION
[Name property is deprecated ](https://registry.terraform.io/providers/-/aws/latest/docs/data-sources/region#name-1)on data.region.current

## Description
Name property of aws_region.current.region is depracated 

## Motivation and Context
This change fixes prevents the warning Terraform generates when applying this module


## Breaking Changes
None

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects

I pulled the repo locally, added my changes and ran terraform init then terraform apply from examples/account-public-access, examples/complete and examples/directory-bucket. 
All applied and deployed within my AWS account. 

- [x] I have executed `pre-commit run -a` on my pull request
