### PR TITLE
fix: Allow for dynamic optional logging

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -54,7 +54,7 @@ resource "aws_s3_directory_bucket" "this" {
 }
 
 resource "aws_s3_bucket_logging" "this" {
-  count = local.create_bucket && length(keys(var.logging)) > 0 && !var.is_directory_bucket ? 1 : 0
+  count = local.create_bucket && length(try(keys(var.logging), [])) > 0 && !var.is_directory_bucket ? 1 : 0
 
   region = var.region
 


### PR DESCRIPTION
## Description
Allow for setting or not setting the logging dynamically using a conditional statement.

## Motivation and Context
```
locals {
  is_production = terraform.workspace == "prod" ? true : false
}

module "s3_bucket" {
  source  = "terraform-aws-modules/s3-bucket/aws"
  [...]

  logging = local.is_production ? {
    target_bucket = module.logs_bucket.s3_bucket_id
    target_prefix = "s3-access-logs/${module.logs_bucket.s3_bucket_id}/"
    target_object_key_format = {
      partitioned_prefix = {
        partition_date_source = "EventTime"
      }
    }
  } : {}
```

When using terraform workspaces, we need to only enable S3 logging in production, or other specific environments, this currently cannot be achieved and was reported in multiple issues, without any answer from the community: https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/issues/314, https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/issues/287, https://github.com/terraform-aws-modules/terraform-aws-s3-bucket/issues/153. Indeed the approach described in those issues could easily be resolved using the wrapper module, but for using terraform workspaces the same solution is not straight forward nor clean.

Currently we run into a type mismatch:

```
Error: Inconsistent conditional result types
The true and false result expressions must have consistent types. The 'true' value includes object attribute "target_bucket", which is absent in the 'false' value.
```

An alternative that is accepted by terraform syntax, is to pass `null` instead of `{}`, but this fails because the module searches for the keys of the `var.logging` variable directly, and breaks with:

```
│ Error: Invalid function argument
│
│   on .terraform/modules/s3_bucket/main.tf line 51, in resource "aws_s3_bucket_logging" "this":
│   51:   count = local.create_bucket && length(keys(var.logging)) > 0 && !var.is_directory_bucket ? 1 : 0
│     ├────────────────
│     │ while calling keys(inputMap)
│     │ var.logging is null
│
│ Invalid value for "inputMap" parameter: argument must not be null.
```

Thus wrapping the `keys()` call in a `try()` block, to capture this would resolve the issue with 0 impact in other scenarios.

## Breaking Changes
There are no breaking changes.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
