### PR TITLE
feat: Add bucket versioning status as an output

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_aws_s3_bucket_versioning_status"></a> [aws\_s3\_bucket\_versioning\_status](#output\_aws\_s3\_bucket\_versioning\_status) | The versioning status of the bucket. Will be 'Enabled', 'Suspended', or 'Disabled'. |
 | <a name="output_s3_bucket_arn"></a> [s3\_bucket\_arn](#output\_s3\_bucket\_arn) | The ARN of the bucket. Will be of format arn:aws:s3:::bucketname. |
 | <a name="output_s3_bucket_bucket_domain_name"></a> [s3\_bucket\_bucket\_domain\_name](#output\_s3\_bucket\_bucket\_domain\_name) | The bucket domain name. Will be of format bucketname.s3.amazonaws.com. |
 | <a name="output_s3_bucket_bucket_regional_domain_name"></a> [s3\_bucket\_bucket\_regional\_domain\_name](#output\_s3\_bucket\_bucket\_regional\_domain\_name) | The bucket region-specific domain name. The bucket domain name including the region name, please refer here for format. Note: The AWS CloudFront allows specifying S3 region-specific endpoint when creating S3 origin, it will prevent redirect issues from CloudFront to S3 Origin URL. |

--- a/outputs.tf
+++ b/outputs.tf
@@ -57,3 +57,8 @@ output "s3_directory_bucket_arn" {
   description = "ARN of the directory bucket."
   value       = try(aws_s3_directory_bucket.this[0].arn, null)
 }
+
+output "aws_s3_bucket_versioning_status" {
+  description = "The versioning status of the bucket. Will be 'Enabled', 'Suspended', or 'Disabled'."
+  value       = try(aws_s3_bucket_versioning.this[0].versioning_configuration[0].status, null)
+}


### PR DESCRIPTION
## Description
When creating replicated buckets, expose a versioning status output in order to be able to create a dependency on replica buckets being ready (versioning enabled). Otherwise applying replication rules targeting a bucket which isn't fully set up may fail.

## Motivation and Context
There is no data source for bucket versioning status or exposed attributes for versioning except the `aws_s3_bucket_versioning` resource which is currently encapsulated by this module.

Take the following (abbreviated) example:

```terraform
module "bucket" {
  source  = "terraform-aws-modules/s3-bucket/aws"
  version = "5.2.0"

  bucket = "my-bucket"

  replication_configuration = {
    ....
  }
  
  versioning = {
    enabled = true
  }
}

module "replica_bucket" {
  source  = "terraform-aws-modules/s3-bucket/aws"
  version = "5.2.0"

  bucket = "my-bucket-replica"

  versioning = {
    enabled = true
  }
}
```

This may result in:

```
Error: creating S3 Bucket (my-bucket) Replication Configuration: operation error S3: PutBucketReplication, https response error StatusCode: 400, RequestID: xxxx, HostID: xxxxx, api error InvalidRequest: Destination bucket must have versioning enabled.
```

The hope is that by depending on the versioning resource could delay replication rule creation until the destination bucket is ready (and has versioning configuration fully applied).

## Breaking Changes
No breaking changes

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
