### PR TITLE
Add Region parameter to Notification module

### DIFF
--- a/modules/notification/README.md
+++ b/modules/notification/README.md
@@ -39,6 +39,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_bucket"></a> [bucket](#input\_bucket) | Name of S3 bucket to use | `string` | `""` | no |
 | <a name="input_bucket_arn"></a> [bucket\_arn](#input\_bucket\_arn) | ARN of S3 bucket to use in policies | `string` | `null` | no |
+| <a name="input_region"></a> [region](#input\_region) | Region where the resource(s) will be managed. Defaults to the region set in the provider configuration | `string` | `null` | no |
 | <a name="input_create"></a> [create](#input\_create) | Whether to create this resource or not? | `bool` | `true` | no |
 | <a name="input_create_lambda_permission"></a> [create\_lambda\_permission](#input\_create\_lambda\_permission) | Whether to create Lambda permissions or not? | `bool` | `true` | no |
 | <a name="input_create_sns_policy"></a> [create\_sns\_policy](#input\_create\_sns\_policy) | Whether to create a policy for SNS permissions or not? | `bool` | `true` | no |

--- a/modules/notification/main.tf
+++ b/modules/notification/main.tf
@@ -13,6 +13,8 @@ resource "aws_s3_bucket_notification" "this" {
 
   bucket = var.bucket
 
+  region = var.region
+
   eventbridge = var.eventbridge
 
   dynamic "lambda_function" {
@@ -62,6 +64,8 @@ resource "aws_s3_bucket_notification" "this" {
 resource "aws_lambda_permission" "allow" {
   for_each = { for k, v in var.lambda_notifications : k => v if var.create_lambda_permission }
 
+  region = var.region
+
   statement_id_prefix = "AllowLambdaS3BucketNotification-"
   action              = "lambda:InvokeFunction"
   function_name       = each.value.function_name
@@ -110,6 +114,8 @@ data "aws_iam_policy_document" "sqs" {
 resource "aws_sqs_queue_policy" "allow" {
   for_each = { for k, v in var.sqs_notifications : k => v if var.create_sqs_policy }
 
+  region = var.region
+
   queue_url = try(each.value.queue_id, local.queue_ids[each.key], null)
   policy    = data.aws_iam_policy_document.sqs[each.key].json
 }
@@ -144,6 +150,8 @@ data "aws_iam_policy_document" "sns" {
 
 resource "aws_sns_topic_policy" "allow" {
   for_each = { for k, v in var.sns_notifications : k => v if var.create_sns_policy }
+
+  region = var.region
 
   arn    = each.value.topic_arn
   policy = data.aws_iam_policy_document.sns[each.key].json

--- a/modules/notification/variables.tf
+++ b/modules/notification/variables.tf
@@ -22,6 +22,12 @@ variable "create_lambda_permission" {
   default     = true
 }
 
+variable "region" {
+  description = "Region where the resource(s) will be managed. Defaults to the region set in the provider configuration"
+  type        = string
+  default     = null
+}
+
 variable "bucket" {
   description = "Name of S3 bucket to use"
   type        = string


### PR DESCRIPTION
## Description
Add Region parameter to Notification module

## Motivation and Context
Now that AWS provider version 6.0.0 supports "region" parameter, add it to the "notification" module.
Resolves #353 

## Breaking Changes
Does not break backward compatibility

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
