### PR TITLE
fix: Fixed placeholders for disabled buckets

### DIFF
--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -45,6 +45,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_cloudfront_log_bucket"></a> [cloudfront\_log\_bucket](#module\_cloudfront\_log\_bucket) | ../../ | n/a |
+| <a name="module_disabled"></a> [disabled](#module\_disabled) | ../../ | n/a |
 | <a name="module_log_bucket"></a> [log\_bucket](#module\_log\_bucket) | ../../ | n/a |
 | <a name="module_s3_bucket"></a> [s3\_bucket](#module\_s3\_bucket) | ../../ | n/a |
 | <a name="module_simple_bucket"></a> [simple\_bucket](#module\_simple\_bucket) | ../../ | n/a |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -410,3 +410,9 @@ module "s3_bucket" {
   #   sse_algorithm = "AES256"
   # }
 }
+
+module "disabled" {
+  source = "../../"
+
+  create_bucket = false
+}

--- a/main.tf
+++ b/main.tf
@@ -18,9 +18,9 @@ locals {
 
   # Placeholders in the policy document to be replaced with the actual values
   policy_placeholders = {
-    "_S3_BUCKET_ID_"   = var.is_directory_bucket ? aws_s3_directory_bucket.this[0].bucket : aws_s3_bucket.this[0].id,
-    "_S3_BUCKET_ARN_"  = var.is_directory_bucket ? aws_s3_directory_bucket.this[0].arn : aws_s3_bucket.this[0].arn,
-    "_AWS_ACCOUNT_ID_" = data.aws_caller_identity.current.account_id
+    "_S3_BUCKET_ID_"   = try(var.is_directory_bucket ? aws_s3_directory_bucket.this[0].bucket : aws_s3_bucket.this[0].id, null),
+    "_S3_BUCKET_ARN_"  = try(var.is_directory_bucket ? aws_s3_directory_bucket.this[0].arn : aws_s3_bucket.this[0].arn, null),
+    "_AWS_ACCOUNT_ID_" = try(data.aws_caller_identity.current.account_id, null)
   }
 
   policy = local.create_bucket && local.attach_policy ? replace(


### PR DESCRIPTION
Added disabled bucket example, which was absent.

Fixed #364 