### PR TITLE
feat: Support `blocked_encryption_types` and table bucket tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,13 +156,13 @@ Users of Terragrunt can achieve similar results by using modules provided in the
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.5 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.22 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.5 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.22 |
 
 ## Modules
 

--- a/examples/account-public-access/README.md
+++ b/examples/account-public-access/README.md
@@ -20,7 +20,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.5 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.22 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers

--- a/examples/account-public-access/versions.tf
+++ b/examples/account-public-access/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.5"
+      version = ">= 6.22"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -30,14 +30,14 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.5 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.22 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.5 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.22 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -241,6 +241,7 @@ module "s3_bucket" {
         kms_master_key_id = aws_kms_key.objects.arn
         sse_algorithm     = "aws:kms"
       }
+      blocked_encryption_types = ["SSE-C"]
     }
   }
 

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.5"
+      version = ">= 6.22"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/directory-bucket/README.md
+++ b/examples/directory-bucket/README.md
@@ -20,14 +20,14 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.5 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.22 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.5 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.22 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules

--- a/examples/directory-bucket/versions.tf
+++ b/examples/directory-bucket/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.5"
+      version = ">= 6.22"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/notification/README.md
+++ b/examples/notification/README.md
@@ -20,7 +20,7 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.5 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.22 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 2.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
@@ -28,7 +28,7 @@ Note that this example may create resources which cost money. Run `terraform des
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.5 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.22 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 2.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 

--- a/examples/notification/versions.tf
+++ b/examples/notification/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.5"
+      version = ">= 6.22"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/object/README.md
+++ b/examples/object/README.md
@@ -20,14 +20,14 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.5 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.22 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.5 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.22 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules

--- a/examples/object/versions.tf
+++ b/examples/object/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.5"
+      version = ">= 6.22"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/s3-analytics/README.md
+++ b/examples/s3-analytics/README.md
@@ -10,14 +10,14 @@ Please check [complete example](https://github.com/terraform-aws-modules/terrafo
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.5 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.22 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.5 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.22 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules

--- a/examples/s3-analytics/versions.tf
+++ b/examples/s3-analytics/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.5"
+      version = ">= 6.22"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/s3-inventory/README.md
+++ b/examples/s3-inventory/README.md
@@ -10,14 +10,14 @@ Please check [complete example](https://github.com/terraform-aws-modules/terrafo
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.5 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.22 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.5 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.22 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules

--- a/examples/s3-inventory/versions.tf
+++ b/examples/s3-inventory/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.5"
+      version = ">= 6.22"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/s3-replication/README.md
+++ b/examples/s3-replication/README.md
@@ -22,15 +22,15 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.5 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.22 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.5 |
-| <a name="provider_aws.replica"></a> [aws.replica](#provider\_aws.replica) | >= 6.5 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.22 |
+| <a name="provider_aws.replica"></a> [aws.replica](#provider\_aws.replica) | >= 6.22 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules

--- a/examples/s3-replication/versions.tf
+++ b/examples/s3-replication/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.5"
+      version = ">= 6.22"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/table-bucket/README.md
+++ b/examples/table-bucket/README.md
@@ -20,14 +20,14 @@ Note that this example may create resources which cost money. Run `terraform des
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.5 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.22 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.5 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.22 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 2.0 |
 
 ## Modules

--- a/examples/table-bucket/main.tf
+++ b/examples/table-bucket/main.tf
@@ -9,6 +9,10 @@ provider "aws" {
 
 locals {
   bucket_name = "s3-table-bucket-${random_pet.this.id}"
+
+  tags = {
+    bucket_name = local.bucket_name
+  }
 }
 
 data "aws_caller_identity" "this" {}
@@ -35,6 +39,8 @@ module "table_bucket" {
       }
     }
   }
+
+  tags = local.tags
 
   create_table_bucket_policy = true
   table_bucket_policy_statements = [
@@ -94,6 +100,10 @@ module "table_bucket" {
           ]
         }
       ]
+
+      tags = {
+        table_name = "table1"
+      }
     }
     table2 = {
       format    = "ICEBERG"

--- a/examples/table-bucket/versions.tf
+++ b/examples/table-bucket/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.5"
+      version = ">= 6.22"
     }
     random = {
       source  = "hashicorp/random"

--- a/main.tf
+++ b/main.tf
@@ -242,6 +242,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
           kms_master_key_id = try(apply_server_side_encryption_by_default.value.kms_master_key_id, null)
         }
       }
+      blocked_encryption_types = try(rule.value.blocked_encryption_types, null)
     }
   }
 }

--- a/modules/account-public-access/README.md
+++ b/modules/account-public-access/README.md
@@ -12,13 +12,13 @@ Each AWS account may only have one S3 Public Access Block configuration.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.5 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.22 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.5 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.22 |
 
 ## Modules
 

--- a/modules/account-public-access/versions.tf
+++ b/modules/account-public-access/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.5"
+      version = ">= 6.22"
     }
   }
 }

--- a/modules/notification/README.md
+++ b/modules/notification/README.md
@@ -8,13 +8,13 @@ Creates S3 bucket notification resource with all supported types of deliveries: 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.5 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.22 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.5 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.22 |
 
 ## Modules
 

--- a/modules/notification/versions.tf
+++ b/modules/notification/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.5"
+      version = ">= 6.22"
     }
   }
 }

--- a/modules/object/README.md
+++ b/modules/object/README.md
@@ -8,13 +8,13 @@ Creates S3 bucket objects with different configurations.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.5 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.22 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.5 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.22 |
 
 ## Modules
 

--- a/modules/object/versions.tf
+++ b/modules/object/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.5"
+      version = ">= 6.22"
     }
   }
 }

--- a/modules/table-bucket/README.md
+++ b/modules/table-bucket/README.md
@@ -8,13 +8,13 @@ Creates S3 Table Bucket and Tables with various configurations.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.5.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.5 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.22 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.5 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.22 |
 
 ## Modules
 
@@ -46,6 +46,7 @@ No modules.
 | <a name="input_table_bucket_policy_statements"></a> [table\_bucket\_policy\_statements](#input\_table\_bucket\_policy\_statements) | A map of IAM policy [statements](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document#statement) for custom permission usage | `any` | `{}` | no |
 | <a name="input_table_bucket_source_policy_documents"></a> [table\_bucket\_source\_policy\_documents](#input\_table\_bucket\_source\_policy\_documents) | List of IAM policy documents that are merged together into the exported document. Statements must have unique `sid`s | `list(string)` | `[]` | no |
 | <a name="input_tables"></a> [tables](#input\_tables) | Map of table configurations | `any` | `{}` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Key-value map of resource tags | `map(string)` | `null` | no |
 
 ## Outputs
 

--- a/modules/table-bucket/README.md
+++ b/modules/table-bucket/README.md
@@ -46,7 +46,7 @@ No modules.
 | <a name="input_table_bucket_policy_statements"></a> [table\_bucket\_policy\_statements](#input\_table\_bucket\_policy\_statements) | A map of IAM policy [statements](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document#statement) for custom permission usage | `any` | `{}` | no |
 | <a name="input_table_bucket_source_policy_documents"></a> [table\_bucket\_source\_policy\_documents](#input\_table\_bucket\_source\_policy\_documents) | List of IAM policy documents that are merged together into the exported document. Statements must have unique `sid`s | `list(string)` | `[]` | no |
 | <a name="input_tables"></a> [tables](#input\_tables) | Map of table configurations | `any` | `{}` | no |
-| <a name="input_tags"></a> [tags](#input\_tags) | Key-value map of resource tags | `map(string)` | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Key-value map of resource tags | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/modules/table-bucket/main.tf
+++ b/modules/table-bucket/main.tf
@@ -6,6 +6,8 @@ resource "aws_s3tables_table_bucket" "this" {
   name                      = var.table_bucket_name
   encryption_configuration  = var.encryption_configuration
   maintenance_configuration = var.maintenance_configuration
+
+  tags = var.tags
 }
 
 resource "aws_s3tables_table_bucket_policy" "this" {
@@ -76,6 +78,7 @@ resource "aws_s3tables_table" "this" {
   table_bucket_arn          = aws_s3tables_table_bucket.this[0].arn
   encryption_configuration  = try(each.value.encryption_configuration, null)
   maintenance_configuration = try(each.value.maintenance_configuration, null)
+  tags                      = merge(var.tags, try(each.value.tags, {}))
 
   dynamic "metadata" {
     for_each = try([each.value.metadata], [])

--- a/modules/table-bucket/variables.tf
+++ b/modules/table-bucket/variables.tf
@@ -67,5 +67,5 @@ variable "tables" {
 variable "tags" {
   description = "Key-value map of resource tags"
   type        = map(string)
-  default     = null
+  default     = {}
 }

--- a/modules/table-bucket/variables.tf
+++ b/modules/table-bucket/variables.tf
@@ -63,3 +63,9 @@ variable "tables" {
   type        = any
   default     = {}
 }
+
+variable "tags" {
+  description = "Key-value map of resource tags"
+  type        = map(string)
+  default     = null
+}

--- a/modules/table-bucket/versions.tf
+++ b/modules/table-bucket/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.5"
+      version = ">= 6.22"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.5"
+      version = ">= 6.22"
     }
   }
 }

--- a/wrappers/account-public-access/versions.tf
+++ b/wrappers/account-public-access/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.5"
+      version = ">= 6.22"
     }
   }
 }

--- a/wrappers/notification/versions.tf
+++ b/wrappers/notification/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.5"
+      version = ">= 6.22"
     }
   }
 }

--- a/wrappers/object/versions.tf
+++ b/wrappers/object/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.5"
+      version = ">= 6.22"
     }
   }
 }

--- a/wrappers/table-bucket/main.tf
+++ b/wrappers/table-bucket/main.tf
@@ -14,5 +14,5 @@ module "wrapper" {
   table_bucket_policy_statements         = try(each.value.table_bucket_policy_statements, var.defaults.table_bucket_policy_statements, {})
   table_bucket_source_policy_documents   = try(each.value.table_bucket_source_policy_documents, var.defaults.table_bucket_source_policy_documents, [])
   tables                                 = try(each.value.tables, var.defaults.tables, {})
-  tags                                   = try(each.value.tags, var.defaults.tags, null)
+  tags                                   = try(each.value.tags, var.defaults.tags, {})
 }

--- a/wrappers/table-bucket/main.tf
+++ b/wrappers/table-bucket/main.tf
@@ -14,4 +14,5 @@ module "wrapper" {
   table_bucket_policy_statements         = try(each.value.table_bucket_policy_statements, var.defaults.table_bucket_policy_statements, {})
   table_bucket_source_policy_documents   = try(each.value.table_bucket_source_policy_documents, var.defaults.table_bucket_source_policy_documents, [])
   tables                                 = try(each.value.tables, var.defaults.tables, {})
+  tags                                   = try(each.value.tags, var.defaults.tags, null)
 }

--- a/wrappers/table-bucket/versions.tf
+++ b/wrappers/table-bucket/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.5"
+      version = ">= 6.22"
     }
   }
 }

--- a/wrappers/versions.tf
+++ b/wrappers/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.5"
+      version = ">= 6.22"
     }
   }
 }


### PR DESCRIPTION
## Description
Support for `server_side_encryption_configuration.blocked_encryption_types`. 
Support `aws_s3tables_table_bucket.tags` and `aws_s3tables_table.tags`. 

## Motivation and Context
- https://github.com/hashicorp/terraform-provider-aws/pull/44996
- https://github.com/hashicorp/terraform-provider-aws/pull/45105

## Breaking Changes
No. 

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
