### PR TITLE
fix: Replace static `aws` partition with dynamic data source

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -909,7 +909,7 @@ data "aws_iam_policy_document" "waf_log_delivery" {
 
     condition {
       test     = "ArnLike"
-      values   = ["arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.id}:*"]
+      values   = ["arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.id}:*"]
       variable = "aws:SourceArn"
     }
   }
@@ -940,7 +940,7 @@ data "aws_iam_policy_document" "waf_log_delivery" {
 
     condition {
       test     = "ArnLike"
-      values   = ["arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.id}:*"]
+      values   = ["arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.id}:*"]
       variable = "aws:SourceArn"
     }
   }


### PR DESCRIPTION
## Description
Use the actual AWS partition for WAF log delivery policy instead of assuming "aws".

## Motivation and Context
Allows WAF delivery (also works for VPC Flow Logs) policy to be used in other AWS partitions.

## Breaking Changes
None, users on AWS commercial cloud will not have policies changed.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
Also, I have deployed this in a GovCloud account and verified VPC Flow Log delivery occurs.