### PR TITLE
feat: Support S3 bucket ABAC

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ These features of S3 bucket configurations are supported:
 - Account-level Public Access Block
 - S3 Directory Bucket
 - S3 Table Bucket
+- S3 Bucket ABAC (Attribute Based Access Control)
 
 ## Usage
 
@@ -94,6 +95,20 @@ module "s3_bucket_for_waf_logs" {
   object_ownership         = "ObjectWriter"
 
   attach_waf_log_delivery_policy = true  # Required for WAF logs
+}
+```
+
+### Bucket with ABAC enabled
+
+```hcl
+module "s3_bucket" {
+  source = "terraform-aws-modules/s3-bucket/aws"
+
+  bucket = "my-s3-bucket"
+
+  abac_status = {
+    status = "Enabled"
+  }
 }
 ```
 
@@ -173,6 +188,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_s3_bucket.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_abac.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_abac) | resource |
 | [aws_s3_bucket_accelerate_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_accelerate_configuration) | resource |
 | [aws_s3_bucket_acl.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) | resource |
 | [aws_s3_bucket_analytics_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_analytics_configuration) | resource |
@@ -215,6 +231,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_abac_status"></a> [abac\_status](#input\_abac\_status) | Map containing ABAC (Attribute Based Access Control) configuration | `any` | `{}` | no |
 | <a name="input_acceleration_status"></a> [acceleration\_status](#input\_acceleration\_status) | (Optional) Sets the accelerate configuration of an existing bucket. Can be Enabled or Suspended. | `string` | `null` | no |
 | <a name="input_access_log_delivery_policy_source_accounts"></a> [access\_log\_delivery\_policy\_source\_accounts](#input\_access\_log\_delivery\_policy\_source\_accounts) | (Optional) List of AWS Account IDs should be allowed to deliver access logs to this bucket. | `list(string)` | `[]` | no |
 | <a name="input_access_log_delivery_policy_source_buckets"></a> [access\_log\_delivery\_policy\_source\_buckets](#input\_access\_log\_delivery\_policy\_source\_buckets) | (Optional) List of S3 bucket ARNs which should be allowed to deliver access logs to this bucket. | `list(string)` | `[]` | no |
@@ -292,6 +309,7 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_aws_s3_bucket_versioning_status"></a> [aws\_s3\_bucket\_versioning\_status](#output\_aws\_s3\_bucket\_versioning\_status) | The versioning status of the bucket. Will be 'Enabled', 'Suspended', or 'Disabled'. |
+| <a name="output_s3_bucket_abac_status"></a> [s3\_bucket\_abac\_status](#output\_s3\_bucket\_abac\_status) | The ABAC status of the bucket. |
 | <a name="output_s3_bucket_arn"></a> [s3\_bucket\_arn](#output\_s3\_bucket\_arn) | The ARN of the bucket. Will be of format arn:aws:s3:::bucketname. |
 | <a name="output_s3_bucket_bucket_domain_name"></a> [s3\_bucket\_bucket\_domain\_name](#output\_s3\_bucket\_bucket\_domain\_name) | The bucket domain name. Will be of format bucketname.s3.amazonaws.com. |
 | <a name="output_s3_bucket_bucket_regional_domain_name"></a> [s3\_bucket\_bucket\_regional\_domain\_name](#output\_s3\_bucket\_bucket\_regional\_domain\_name) | The bucket region-specific domain name. The bucket domain name including the region name, please refer here for format. Note: The AWS CloudFront allows specifying S3 region-specific endpoint when creating S3 origin, it will prevent redirect issues from CloudFront to S3 Origin URL. |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -70,6 +70,7 @@ No inputs.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_s3_bucket_abac_status"></a> [s3\_bucket\_abac\_status](#output\_s3\_bucket\_abac\_status) | The ABAC status of the bucket. |
 | <a name="output_s3_bucket_arn"></a> [s3\_bucket\_arn](#output\_s3\_bucket\_arn) | The ARN of the bucket. Will be of format arn:aws:s3:::bucketname. |
 | <a name="output_s3_bucket_bucket_domain_name"></a> [s3\_bucket\_bucket\_domain\_name](#output\_s3\_bucket\_bucket\_domain\_name) | The bucket domain name. Will be of format bucketname.s3.amazonaws.com. |
 | <a name="output_s3_bucket_bucket_regional_domain_name"></a> [s3\_bucket\_bucket\_regional\_domain\_name](#output\_s3\_bucket\_bucket\_regional\_domain\_name) | The bucket region-specific domain name. The bucket domain name including the region name, please refer here for format. Note: The AWS CloudFront allows specifying S3 region-specific endpoint when creating S3 origin, it will prevent redirect issues from CloudFront to S3 Origin URL. |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -410,6 +410,10 @@ module "s3_bucket" {
   # metadata_encryption_configuration = {
   #   sse_algorithm = "AES256"
   # }
+
+  abac_status = {
+    status = "Enabled"
+  }
 }
 
 module "disabled" {

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -47,3 +47,8 @@ output "s3_bucket_website_domain" {
   description = "The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records. "
   value       = module.s3_bucket.s3_bucket_website_domain
 }
+
+output "s3_bucket_abac_status" {
+  description = "The ABAC status of the bucket."
+  value       = module.s3_bucket.s3_bucket_abac_status
+}

--- a/main.tf
+++ b/main.tf
@@ -1409,3 +1409,16 @@ resource "aws_s3_bucket_metadata_configuration" "this" {
     }
   }
 }
+
+resource "aws_s3_bucket_abac" "this" {
+  count = local.create_bucket && length(keys(var.abac_status)) > 0 && !var.is_directory_bucket ? 1 : 0
+
+  region = var.region
+
+  bucket                = aws_s3_bucket.this[0].bucket
+  expected_bucket_owner = var.expected_bucket_owner
+
+  abac_status {
+    status = try(var.abac_status["status"], "Enabled")
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -67,3 +67,8 @@ output "s3_bucket_tags" {
   description = "Tags of the bucket."
   value       = try(aws_s3_bucket.this[0].tags, {})
 }
+
+output "s3_bucket_abac_status" {
+  description = "The ABAC status of the bucket."
+  value       = try(aws_s3_bucket_abac.this[0].abac_status[0].status, null)
+}

--- a/variables.tf
+++ b/variables.tf
@@ -419,6 +419,12 @@ variable "metadata_journal_table_record_expiration" {
   default     = null
 }
 
+variable "abac_status" {
+  description = "Map containing ABAC (Attribute Based Access Control) configuration"
+  type        = any
+  default     = {}
+}
+
 variable "putin_khuylo" {
   description = "Do you agree that Putin doesn't respect Ukrainian sovereignty and territorial integrity? More info: https://en.wikipedia.org/wiki/Putin_khuylo!"
   type        = bool

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -3,6 +3,7 @@ module "wrapper" {
 
   for_each = var.items
 
+  abac_status                                     = try(each.value.abac_status, var.defaults.abac_status, {})
   acceleration_status                             = try(each.value.acceleration_status, var.defaults.acceleration_status, null)
   access_log_delivery_policy_source_accounts      = try(each.value.access_log_delivery_policy_source_accounts, var.defaults.access_log_delivery_policy_source_accounts, [])
   access_log_delivery_policy_source_buckets       = try(each.value.access_log_delivery_policy_source_buckets, var.defaults.access_log_delivery_policy_source_buckets, [])


### PR DESCRIPTION
## Description
Add support for S3 bucket Attribute-Based Access Control (ABAC) on general-purpose buckets.
- [aws_s3_bucket_abac r/aws_s3_bucket: ABAC support](https://github.com/hashicorp/terraform-provider-aws/pull/45251).

## Motivation and Context
- Resolves #372


## Breaking Changes

No.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request

