### PR TITLE
fix(lifecycle): filter null values from dynamic blocks

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -321,7 +321,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "this" {
 
       # Max 1 block - expiration
       dynamic "expiration" {
-        for_each = try(flatten([rule.value.expiration]), [])
+        for_each = [for v in try(flatten([rule.value.expiration]), []) : v if v != null]
 
         content {
           date                         = try(expiration.value.date, null)
@@ -343,7 +343,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "this" {
 
       # Max 1 block - noncurrent_version_expiration
       dynamic "noncurrent_version_expiration" {
-        for_each = try(flatten([rule.value.noncurrent_version_expiration]), [])
+        for_each = [for v in try(flatten([rule.value.noncurrent_version_expiration]), []) : v if v != null]
 
         content {
           newer_noncurrent_versions = try(noncurrent_version_expiration.value.newer_noncurrent_versions, null)
@@ -364,7 +364,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "this" {
 
       # Max 1 block - filter - without any key arguments or tags
       dynamic "filter" {
-        for_each = length(try(flatten([rule.value.filter]), [])) == 0 ? [true] : []
+        for_each = length([for v in try(flatten([rule.value.filter]), []) : v if v != null]) == 0 ? [true] : []
 
         content {
           #          prefix = ""
@@ -373,7 +373,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "this" {
 
       # Max 1 block - filter - with one key argument or a single tag
       dynamic "filter" {
-        for_each = [for v in try(flatten([rule.value.filter]), []) : v if max(length(keys(v)), length(try(rule.value.filter.tags, rule.value.filter.tag, []))) == 1]
+        for_each = [for v in try(flatten([rule.value.filter]), []) : v if v != null && max(length(keys(v)), length(try(rule.value.filter.tags, rule.value.filter.tag, []))) == 1]
 
         content {
           object_size_greater_than = try(filter.value.object_size_greater_than, null)
@@ -393,7 +393,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "this" {
 
       # Max 1 block - filter - with more than one key arguments or multiple tags
       dynamic "filter" {
-        for_each = [for v in try(flatten([rule.value.filter]), []) : v if max(length(keys(v)), length(try(rule.value.filter.tags, rule.value.filter.tag, []))) > 1]
+        for_each = [for v in try(flatten([rule.value.filter]), []) : v if v != null && max(length(keys(v)), length(try(rule.value.filter.tags, rule.value.filter.tag, []))) > 1]
 
         content {
           and {
@@ -558,7 +558,7 @@ resource "aws_s3_bucket_replication_configuration" "this" {
 
       # Max 1 block - filter - without any key arguments or tags
       dynamic "filter" {
-        for_each = length(try(flatten([rule.value.filter]), [])) == 0 ? [true] : []
+        for_each = length([for v in try(flatten([rule.value.filter]), []) : v if v != null]) == 0 ? [true] : []
 
         content {
         }
@@ -566,7 +566,7 @@ resource "aws_s3_bucket_replication_configuration" "this" {
 
       # Max 1 block - filter - with one key argument or a single tag
       dynamic "filter" {
-        for_each = [for v in try(flatten([rule.value.filter]), []) : v if max(length(keys(v)), length(try(rule.value.filter.tags, rule.value.filter.tag, []))) == 1]
+        for_each = [for v in try(flatten([rule.value.filter]), []) : v if v != null && max(length(keys(v)), length(try(rule.value.filter.tags, rule.value.filter.tag, []))) == 1]
 
         content {
           prefix = try(filter.value.prefix, null)
@@ -584,7 +584,7 @@ resource "aws_s3_bucket_replication_configuration" "this" {
 
       # Max 1 block - filter - with more than one key arguments or multiple tags
       dynamic "filter" {
-        for_each = [for v in try(flatten([rule.value.filter]), []) : v if max(length(keys(v)), length(try(rule.value.filter.tags, rule.value.filter.tag, []))) > 1]
+        for_each = [for v in try(flatten([rule.value.filter]), []) : v if v != null && max(length(keys(v)), length(try(rule.value.filter.tags, rule.value.filter.tag, []))) > 1]
 
         content {
           and {

--- a/main.tf
+++ b/main.tf
@@ -332,7 +332,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "this" {
 
       # Several blocks - transition
       dynamic "transition" {
-        for_each = try(flatten([rule.value.transition]), [])
+        for_each = [for v in try(flatten([rule.value.transition]), []) : v if v != null]
 
         content {
           date          = try(transition.value.date, null)
@@ -353,7 +353,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "this" {
 
       # Several blocks - noncurrent_version_transition
       dynamic "noncurrent_version_transition" {
-        for_each = try(flatten([rule.value.noncurrent_version_transition]), [])
+        for_each = [for v in try(flatten([rule.value.noncurrent_version_transition]), []) : v if v != null]
 
         content {
           newer_noncurrent_versions = try(noncurrent_version_transition.value.newer_noncurrent_versions, null)


### PR DESCRIPTION
## Description

When lifecycle_rule attributes (`expiration`, `transition`, `noncurrent_version_expiration`, `noncurrent_version_transition`, `filter`) are `null`, `flatten([null])` returns `[null]` (not `[]`), causing dynamic blocks to iterate once with a null value.

### Problems this causes:

1. **expiration / noncurrent_version_expiration**: Creates empty blocks with default values (`days=0`, `expired_object_delete_marker=false`). AWS rejects `expired_object_delete_marker` when combined with object size filters, causing apply failures even when expiration wasn't specified.

2. **transition / noncurrent_version_transition**: Creates empty blocks that could cause unexpected behavior or API errors when `storage_class` is required but missing.

3. **filter**: When filter is `null`, the empty filter block isn't created (since `length([null]) == 1`, not `0`), requiring users to work around it by passing `filter = {}` instead of omitting it.

### Fix

Filter null values from flattened lists before iteration:

```hcl
# Before
for_each = try(flatten([rule.value.expiration]), [])

# After  
for_each = [for v in try(flatten([rule.value.expiration]), []) : v if v != null]
```

This preserves backwards compatibility for list inputs while correctly handling null values.

### Files changed

- `main.tf`: Updated 8 dynamic block `for_each` expressions:
  - `expiration`
  - `transition`
  - `noncurrent_version_expiration`
  - `noncurrent_version_transition`
  - 3 `filter` blocks in lifecycle configuration
  - 3 `filter` blocks in replication configuration

### Testing

Tested with a real Terraform configuration that previously failed with:
```
Error: api error InvalidRequest: ExpiredObjectDeleteMarker cannot be specified with Object Size.
```

After this fix, the configuration applies successfully without requiring any workarounds in the calling module.