### PR TITLE
fix: Removed object_lock_enabled variable in aws_s3_bucket resource

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -51,7 +51,11 @@ resource "aws_s3_bucket" "this" {
   bucket_prefix = var.bucket_prefix
 
   force_destroy       = var.force_destroy
-  object_lock_enabled = var.object_lock_enabled
+  /* 
+  Stop using object lock in resource aws_s3_bucket to prevent resource deletion. 
+   newer versions of terraform handles object lock in aws_s3_bucket_object_lock_configuration
+  */
+  //object_lock_enabled = var.object_lock_enabled
   tags                = var.tags
 }
 


### PR DESCRIPTION

## Description
The module should follow what aws console offers. aws_s3_bucket_object_lock_configuration will handle object lock enable and disable, default retention etc. Using this variable here was causing resources to be forced replaced / errors in pipeline with newer versions of terraform

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The Change will prevent deletion of s3 bucket in case object lock value is update i.e either from true to false or false to true.aws_s3_bucket_object_lock_configuration works as expected and matches the AWS console. 
Also this is deprecated as per Terraform documentation https://registry.terraform.io/providers/-/aws/6.33.0/docs/resources/s3_bucket
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
