### PR TITLE
Fix: Warnings on deprecated `expected_bucket_owner` attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,6 @@ No modules.
 | <a name="input_create_bucket"></a> [create\_bucket](#input\_create\_bucket) | Controls if S3 bucket should be created | `bool` | `true` | no |
 | <a name="input_create_metadata_configuration"></a> [create\_metadata\_configuration](#input\_create\_metadata\_configuration) | Whether to create metadata configuration resource | `bool` | `false` | no |
 | <a name="input_data_redundancy"></a> [data\_redundancy](#input\_data\_redundancy) | Data redundancy. Valid values: `SingleAvailabilityZone` | `string` | `null` | no |
-| <a name="input_expected_bucket_owner"></a> [expected\_bucket\_owner](#input\_expected\_bucket\_owner) | The account ID of the expected bucket owner | `string` | `null` | no |
 | <a name="input_force_destroy"></a> [force\_destroy](#input\_force\_destroy) | (Optional, Default:false ) A boolean that indicates all objects should be deleted from the bucket so that the bucket can be destroyed without error. These objects are not recoverable. | `bool` | `false` | no |
 | <a name="input_grant"></a> [grant](#input\_grant) | An ACL policy grant. Conflicts with `acl` | `any` | `[]` | no |
 | <a name="input_ignore_public_acls"></a> [ignore\_public\_acls](#input\_ignore\_public\_acls) | Whether Amazon S3 should ignore public ACLs for this bucket. | `bool` | `true` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -196,7 +196,6 @@ module "s3_bucket" {
   control_object_ownership = true
   object_ownership         = "BucketOwnerPreferred"
 
-  expected_bucket_owner                  = data.aws_caller_identity.current.account_id
   transition_default_minimum_object_size = "varies_by_storage_class"
 
   acl = "private" # "acl" conflicts with "grant" and "owner"

--- a/main.tf
+++ b/main.tf
@@ -110,8 +110,7 @@ resource "aws_s3_bucket_acl" "this" {
 
   region = var.region
 
-  bucket                = aws_s3_bucket.this[0].id
-  expected_bucket_owner = var.expected_bucket_owner
+  bucket = aws_s3_bucket.this[0].id
 
   # hack when `null` value can't be used (eg, from terragrunt, https://github.com/gruntwork-io/terragrunt/pull/1367)
   acl = var.acl == "null" ? null : var.acl
@@ -151,8 +150,7 @@ resource "aws_s3_bucket_website_configuration" "this" {
 
   region = var.region
 
-  bucket                = aws_s3_bucket.this[0].id
-  expected_bucket_owner = var.expected_bucket_owner
+  bucket = aws_s3_bucket.this[0].id
 
   dynamic "index_document" {
     for_each = try([var.website["index_document"]], [])
@@ -208,9 +206,8 @@ resource "aws_s3_bucket_versioning" "this" {
 
   region = var.region
 
-  bucket                = aws_s3_bucket.this[0].id
-  expected_bucket_owner = var.expected_bucket_owner
-  mfa                   = try(var.versioning["mfa"], null)
+  bucket = aws_s3_bucket.this[0].id
+  mfa    = try(var.versioning["mfa"], null)
 
   versioning_configuration {
     # Valid values: "Enabled" or "Suspended"
@@ -226,8 +223,7 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "this" {
 
   region = var.region
 
-  bucket                = var.is_directory_bucket ? aws_s3_directory_bucket.this[0].bucket : aws_s3_bucket.this[0].id
-  expected_bucket_owner = var.expected_bucket_owner
+  bucket = var.is_directory_bucket ? aws_s3_directory_bucket.this[0].bucket : aws_s3_bucket.this[0].id
 
   dynamic "rule" {
     for_each = try(flatten([var.server_side_encryption_configuration["rule"]]), [])
@@ -253,8 +249,7 @@ resource "aws_s3_bucket_accelerate_configuration" "this" {
 
   region = var.region
 
-  bucket                = aws_s3_bucket.this[0].id
-  expected_bucket_owner = var.expected_bucket_owner
+  bucket = aws_s3_bucket.this[0].id
 
   # Valid values: "Enabled" or "Suspended"
   status = title(lower(var.acceleration_status))
@@ -265,8 +260,7 @@ resource "aws_s3_bucket_request_payment_configuration" "this" {
 
   region = var.region
 
-  bucket                = aws_s3_bucket.this[0].id
-  expected_bucket_owner = var.expected_bucket_owner
+  bucket = aws_s3_bucket.this[0].id
 
   # Valid values: "BucketOwner" or "Requester"
   payer = lower(var.request_payer) == "requester" ? "Requester" : "BucketOwner"
@@ -277,8 +271,7 @@ resource "aws_s3_bucket_cors_configuration" "this" {
 
   region = var.region
 
-  bucket                = aws_s3_bucket.this[0].id
-  expected_bucket_owner = var.expected_bucket_owner
+  bucket = aws_s3_bucket.this[0].id
 
   dynamic "cors_rule" {
     for_each = local.cors_rules
@@ -300,7 +293,6 @@ resource "aws_s3_bucket_lifecycle_configuration" "this" {
   region = var.region
 
   bucket                                 = var.is_directory_bucket ? aws_s3_directory_bucket.this[0].bucket : aws_s3_bucket.this[0].id
-  expected_bucket_owner                  = var.expected_bucket_owner
   transition_default_minimum_object_size = var.transition_default_minimum_object_size
 
   dynamic "rule" {
@@ -421,9 +413,8 @@ resource "aws_s3_bucket_object_lock_configuration" "this" {
 
   region = var.region
 
-  bucket                = aws_s3_bucket.this[0].id
-  expected_bucket_owner = var.expected_bucket_owner
-  token                 = try(var.object_lock_configuration.token, null)
+  bucket = aws_s3_bucket.this[0].id
+  token  = try(var.object_lock_configuration.token, null)
 
   rule {
     default_retention {

--- a/variables.tf
+++ b/variables.tf
@@ -220,12 +220,6 @@ variable "owner" {
   default     = {}
 }
 
-variable "expected_bucket_owner" {
-  description = "The account ID of the expected bucket owner"
-  type        = string
-  default     = null
-}
-
 variable "transition_default_minimum_object_size" {
   description = "The default minimum object size behavior applied to the lifecycle configuration. Valid values: all_storage_classes_128K (default), varies_by_storage_class"
   type        = string

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -39,7 +39,6 @@ module "wrapper" {
   create_bucket                                   = try(each.value.create_bucket, var.defaults.create_bucket, true)
   create_metadata_configuration                   = try(each.value.create_metadata_configuration, var.defaults.create_metadata_configuration, false)
   data_redundancy                                 = try(each.value.data_redundancy, var.defaults.data_redundancy, null)
-  expected_bucket_owner                           = try(each.value.expected_bucket_owner, var.defaults.expected_bucket_owner, null)
   force_destroy                                   = try(each.value.force_destroy, var.defaults.force_destroy, false)
   grant                                           = try(each.value.grant, var.defaults.grant, [])
   ignore_public_acls                              = try(each.value.ignore_public_acls, var.defaults.ignore_public_acls, true)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
