### PR TITLE
feat: Support null value for replication_configuration (Closes #379)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -435,7 +435,7 @@ resource "aws_s3_bucket_object_lock_configuration" "this" {
 }
 
 resource "aws_s3_bucket_replication_configuration" "this" {
-  count = local.create_bucket && length(keys(var.replication_configuration)) > 0 && !var.is_directory_bucket ? 1 : 0
+  count = local.create_bucket && var.replication_configuration != null && length(keys(var.replication_configuration)) > 0 && !var.is_directory_bucket ? 1 : 0
 
   region = var.region
 

--- a/variables.tf
+++ b/variables.tf
@@ -239,7 +239,7 @@ variable "lifecycle_rule" {
 }
 
 variable "replication_configuration" {
-  description = "Map containing cross-region replication configuration."
+  description = "Map containing cross-region replication configuration. Set to `null` to disable replication (useful for conditional enabling)."
   type        = any
   default     = {}
 }


### PR DESCRIPTION
## Description
Support `null` value for `replication_configuration` variable to allow clean conditional enabling of replication.

## Motivation and Context
Closes #379

Many users want to conditionally enable replication using a boolean flag, like this:


`replication_configuration = var.enable_replication ? {`
`role = "..."`
`rules = [...]`
`} : null`


Previously, passing null caused an error because length(keys(null)) is invalid in the count meta-argument.
This change makes the common conditional pattern work while keeping all existing behavior unchanged.

## Breaking Changes
None. This is fully backwards compatible.

## How Has This Been Tested?

 I have tested and validated these changes using one or more of the provided examples/* projects
 I have executed pre-commit run -a on my pull request (if applicable)

## Testing done:

Ran terraform validate successfully
Confirmed existing behavior with replication_configuration = {} still works
Verified the new conditional null pattern now works without error