### PR TITLE
feat: Support S3 bucket ABAC (Supersedes #370)

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ No modules.
 | Name | Type |
 | ---- | ---- |
 | [aws_s3_bucket.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_abac.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_abac) | resource |
 | [aws_s3_bucket_accelerate_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_accelerate_configuration) | resource |
 | [aws_s3_bucket_acl.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) | resource |
 | [aws_s3_bucket_analytics_configuration.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_analytics_configuration) | resource |
@@ -217,6 +218,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 | ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_abac_status"></a> [abac\_status](#input\_abac\_status) | ABAC (Attribute Based Access Control) status for a general-purpose S3 bucket. | <pre>object({<br/>    status = optional(string, "Enabled")<br/>  })</pre> | `null` | no |
 | <a name="input_acceleration_status"></a> [acceleration\_status](#input\_acceleration\_status) | (Optional) Sets the accelerate configuration of an existing bucket. Can be Enabled or Suspended. | `string` | `null` | no |
 | <a name="input_access_log_delivery_policy_source_accounts"></a> [access\_log\_delivery\_policy\_source\_accounts](#input\_access\_log\_delivery\_policy\_source\_accounts) | (Optional) List of AWS Account IDs should be allowed to deliver access logs to this bucket. | `list(string)` | `[]` | no |
 | <a name="input_access_log_delivery_policy_source_buckets"></a> [access\_log\_delivery\_policy\_source\_buckets](#input\_access\_log\_delivery\_policy\_source\_buckets) | (Optional) List of S3 bucket ARNs which should be allowed to deliver access logs to this bucket. | `list(string)` | `[]` | no |
@@ -295,6 +297,7 @@ No modules.
 | Name | Description |
 | ---- | ----------- |
 | <a name="output_aws_s3_bucket_versioning_status"></a> [aws\_s3\_bucket\_versioning\_status](#output\_aws\_s3\_bucket\_versioning\_status) | The versioning status of the bucket. Will be 'Enabled', 'Suspended', or 'Disabled'. |
+| <a name="output_s3_bucket_abac_status"></a> [s3\_bucket\_abac\_status](#output\_s3\_bucket\_abac\_status) | The ABAC status of the bucket. |
 | <a name="output_s3_bucket_arn"></a> [s3\_bucket\_arn](#output\_s3\_bucket\_arn) | The ARN of the bucket. Will be of format arn:aws:s3:::bucketname. |
 | <a name="output_s3_bucket_bucket_domain_name"></a> [s3\_bucket\_bucket\_domain\_name](#output\_s3\_bucket\_bucket\_domain\_name) | The bucket domain name. Will be of format bucketname.s3.amazonaws.com. |
 | <a name="output_s3_bucket_bucket_namespace"></a> [s3\_bucket\_bucket\_namespace](#output\_s3\_bucket\_bucket\_namespace) | The namespace of the bucket. |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -72,6 +72,7 @@ No inputs.
 
 | Name | Description |
 | ---- | ----------- |
+| <a name="output_s3_bucket_abac_status"></a> [s3\_bucket\_abac\_status](#output\_s3\_bucket\_abac\_status) | The ABAC status of the bucket. |
 | <a name="output_s3_bucket_arn"></a> [s3\_bucket\_arn](#output\_s3\_bucket\_arn) | The ARN of the bucket. Will be of format arn:aws:s3:::bucketname. |
 | <a name="output_s3_bucket_bucket_domain_name"></a> [s3\_bucket\_bucket\_domain\_name](#output\_s3\_bucket\_bucket\_domain\_name) | The bucket domain name. Will be of format bucketname.s3.amazonaws.com. |
 | <a name="output_s3_bucket_bucket_regional_domain_name"></a> [s3\_bucket\_bucket\_regional\_domain\_name](#output\_s3\_bucket\_bucket\_regional\_domain\_name) | The bucket region-specific domain name. The bucket domain name including the region name, please refer here for format. Note: The AWS CloudFront allows specifying S3 region-specific endpoint when creating S3 origin, it will prevent redirect issues from CloudFront to S3 Origin URL. |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -158,6 +158,10 @@ module "s3_bucket" {
   acceleration_status = "Suspended"
   request_payer       = "BucketOwner"
 
+  abac_status = {
+    status = "Enabled"
+  }
+
   tags = {
     Owner = "Anton"
   }

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -47,3 +47,8 @@ output "s3_bucket_website_domain" {
   description = "The domain of the website endpoint, if the bucket is configured with a website. If not, this will be an empty string. This is used to create Route 53 alias records. "
   value       = module.s3_bucket.s3_bucket_website_domain
 }
+
+output "s3_bucket_abac_status" {
+  description = "The ABAC status of the bucket."
+  value       = module.s3_bucket.s3_bucket_abac_status
+}

--- a/main.tf
+++ b/main.tf
@@ -1384,6 +1384,17 @@ resource "aws_s3_bucket_analytics_configuration" "this" {
   }
 }
 
+resource "aws_s3_bucket_abac" "this" {
+  count = local.create_bucket && length(keys(var.abac_status)) > 0 && !var.is_directory_bucket ? 1 : 0
+
+  bucket                = aws_s3_bucket.this[0].id
+  expected_bucket_owner = var.expected_bucket_owner
+
+  abac_status {
+    status = try(var.abac_status["status"], "Enabled")
+  }
+}
+
 resource "aws_s3_bucket_metadata_configuration" "this" {
   count = local.create_bucket && var.create_metadata_configuration ? 1 : 0
 

--- a/main.tf
+++ b/main.tf
@@ -1385,7 +1385,7 @@ resource "aws_s3_bucket_analytics_configuration" "this" {
 }
 
 resource "aws_s3_bucket_abac" "this" {
-  count = local.create_bucket && length(keys(var.abac_status)) > 0 && !var.is_directory_bucket ? 1 : 0
+  count = local.create_bucket && var.abac_status != null && !var.is_directory_bucket ? 1 : 0
 
   bucket                = aws_s3_bucket.this[0].id
   expected_bucket_owner = var.expected_bucket_owner

--- a/outputs.tf
+++ b/outputs.tf
@@ -76,3 +76,8 @@ output "s3_bucket_tags" {
   description = "Tags of the bucket."
   value       = try(aws_s3_bucket.this[0].tags, {})
 }
+
+output "s3_bucket_abac_status" {
+  description = "The ABAC status of the bucket."
+  value       = try(aws_s3_bucket_abac.this[0].abac_status[0].status, null)
+}

--- a/variables.tf
+++ b/variables.tf
@@ -148,6 +148,12 @@ variable "force_destroy" {
   default     = false
 }
 
+variable "abac_status" {
+  description = "Map containing ABAC (Attribute Based Access Control) configuration"
+  type        = any
+  default     = {}
+}
+
 variable "acceleration_status" {
   description = "(Optional) Sets the accelerate configuration of an existing bucket. Can be Enabled or Suspended."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -149,9 +149,19 @@ variable "force_destroy" {
 }
 
 variable "abac_status" {
-  description = "Map containing ABAC (Attribute Based Access Control) configuration"
-  type        = any
-  default     = {}
+  description = "ABAC (Attribute Based Access Control) status for a general-purpose S3 bucket."
+  type = object({
+    status = optional(string, "Enabled")
+  })
+  default = null
+
+  validation {
+    condition = try(
+      contains(["Enabled", "Disabled"], var.abac_status.status),
+      var.abac_status == null
+    )
+    error_message = "The abac_status.status must be 'Enabled' or 'Disabled'."
+  }
 }
 
 variable "acceleration_status" {

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -3,6 +3,7 @@ module "wrapper" {
 
   for_each = var.items
 
+  abac_status                                     = try(each.value.abac_status, var.defaults.abac_status, {})
   acceleration_status                             = try(each.value.acceleration_status, var.defaults.acceleration_status, null)
   access_log_delivery_policy_source_accounts      = try(each.value.access_log_delivery_policy_source_accounts, var.defaults.access_log_delivery_policy_source_accounts, [])
   access_log_delivery_policy_source_buckets       = try(each.value.access_log_delivery_policy_source_buckets, var.defaults.access_log_delivery_policy_source_buckets, [])

--- a/wrappers/main.tf
+++ b/wrappers/main.tf
@@ -3,7 +3,7 @@ module "wrapper" {
 
   for_each = var.items
 
-  abac_status                                     = try(each.value.abac_status, var.defaults.abac_status, {})
+  abac_status                                     = try(each.value.abac_status, var.defaults.abac_status, null)
   acceleration_status                             = try(each.value.acceleration_status, var.defaults.acceleration_status, null)
   access_log_delivery_policy_source_accounts      = try(each.value.access_log_delivery_policy_source_accounts, var.defaults.access_log_delivery_policy_source_accounts, [])
   access_log_delivery_policy_source_buckets       = try(each.value.access_log_delivery_policy_source_buckets, var.defaults.access_log_delivery_policy_source_buckets, [])


### PR DESCRIPTION
## Description
This PR implements Attribute-Based Access Control (ABAC) for general-purpose S3 buckets via the `aws_s3_bucket_abac` resource. 

This directly supersedes and closes #370, which was unfortunately locked from maintainer edits. I have brought the original implementation into alignment with the module's standards by:
- Using `.id` instead of `.bucket` for internal references.
- Removing extraneous `region` arguments from the sub-resource.
- Deferring all documentation updates to the `terraform-docs` pre-commit hook rather than manually modifying the READMEs.

## Motivation and Context
Closes #372. Closes #370. Enables automatic permission management based on tags attached to buckets.

## Breaking Changes
None.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request