### PR TITLE
fix: Prevent deprecation warning on lifecycle rules output (Fixes #389)

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -25,7 +25,11 @@ output "s3_bucket_hosted_zone_id" {
 
 output "s3_bucket_lifecycle_configuration_rules" {
   description = "The lifecycle rules of the bucket, if the bucket is configured with lifecycle rules. If not, this will be an empty string."
-  value       = try(aws_s3_bucket_lifecycle_configuration.this[0].rule, "")
+  value = try([
+    for r in aws_s3_bucket_lifecycle_configuration.this[0].rule : {
+      for k, v in r : k => v if k != "prefix"
+    }
+  ], "")
 }
 
 output "s3_bucket_policy" {


### PR DESCRIPTION
## Description
This PR resolves the persistent deprecation warning introduced in recent Terraform/AWS Provider versions regarding `rule.prefix` on S3 lifecycle configurations. 

Previously, the `s3_bucket_lifecycle_configuration_rules` output exported the raw resource block, causing Terraform to evaluate and warn on the deprecated `prefix` attribute embedded in the provider schema (even when users correctly utilized `filter`). 

This fix intercepts the output and uses a dynamic map omit to strip the `prefix` key before it crosses the module boundary, silencing the false-positive warning for downstream consumers.

## Motivation and Context
Closes #389. Improves module ergonomics and prevents pipeline noise for users on modern AWS provider versions.

## Breaking Changes
None. The output remains structurally identical minus the deprecated, unused key.

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] Verified via `terraform plan` that the deprecation warning is successfully suppressed.