### PR TITLE
feat: Expose bucket_namespace output (References #390)

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ No modules.
 | <a name="output_aws_s3_bucket_versioning_status"></a> [aws\_s3\_bucket\_versioning\_status](#output\_aws\_s3\_bucket\_versioning\_status) | The versioning status of the bucket. Will be 'Enabled', 'Suspended', or 'Disabled'. |
 | <a name="output_s3_bucket_arn"></a> [s3\_bucket\_arn](#output\_s3\_bucket\_arn) | The ARN of the bucket. Will be of format arn:aws:s3:::bucketname. |
 | <a name="output_s3_bucket_bucket_domain_name"></a> [s3\_bucket\_bucket\_domain\_name](#output\_s3\_bucket\_bucket\_domain\_name) | The bucket domain name. Will be of format bucketname.s3.amazonaws.com. |
+| <a name="output_s3_bucket_bucket_namespace"></a> [s3\_bucket\_bucket\_namespace](#output\_s3\_bucket\_bucket\_namespace) | The namespace of the bucket. |
 | <a name="output_s3_bucket_bucket_regional_domain_name"></a> [s3\_bucket\_bucket\_regional\_domain\_name](#output\_s3\_bucket\_bucket\_regional\_domain\_name) | The bucket region-specific domain name. The bucket domain name including the region name, please refer here for format. Note: The AWS CloudFront allows specifying S3 region-specific endpoint when creating S3 origin, it will prevent redirect issues from CloudFront to S3 Origin URL. |
 | <a name="output_s3_bucket_hosted_zone_id"></a> [s3\_bucket\_hosted\_zone\_id](#output\_s3\_bucket\_hosted\_zone\_id) | The Route 53 Hosted Zone ID for this bucket's region. |
 | <a name="output_s3_bucket_id"></a> [s3\_bucket\_id](#output\_s3\_bucket\_id) | The name of the bucket. |

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,6 +18,11 @@ output "s3_bucket_bucket_regional_domain_name" {
   value       = try(aws_s3_bucket.this[0].bucket_regional_domain_name, "")
 }
 
+output "s3_bucket_bucket_namespace" {
+  description = "The namespace of the bucket."
+  value       = try(aws_s3_bucket.this[0].bucket_namespace, null)
+}
+
 output "s3_bucket_hosted_zone_id" {
   description = "The Route 53 Hosted Zone ID for this bucket's region."
   value       = try(aws_s3_bucket.this[0].hosted_zone_id, "")


### PR DESCRIPTION
## Description
While `bucket_namespace` was recently added to the module's variables and main resource block, it was unfortunately left out of `outputs.tf`. This PR exposes `s3_bucket_bucket_namespace` so downstream consumers can reference the namespace natively.

**Note regarding Issue #390:** I originally looked at implementing the auto-suffixing logic for `bucket_prefix` requested in #390. However, because Terraform natively appends its random hex generation to the absolute end of the `bucket_prefix` string (and AWS requires `-an` at the absolute end), automatically handling this would require overriding the native provider behavior and generating custom `random_string` resources within the module. I deferred implementing that to avoid introducing brittle string manipulation, but wanted to get this missing output up for review!

## Motivation and Context
Completes the integration of the `bucket_namespace` variable. References #390.

## Breaking Changes
None.

## How Has This Been Tested?
- [x] Verified via `terraform validate` that the output mapping evaluates perfectly.
- [x] Executed a full `terraform plan`, `apply`, and `destroy` cycle against a live AWS environment. Confirmed that the AWS API successfully provisions `account-regional` buckets via the module and that the output correctly exports the state.