### PR TITLE
fix: Wildcard region in WAF/Log delivery policy to support CloudFront

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -910,7 +910,7 @@ data "aws_iam_policy_document" "waf_log_delivery" {
 
     condition {
       test     = "ArnLike"
-      values   = ["arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.id}:*"]
+      values   = ["arn:${data.aws_partition.current.partition}:logs:*:${data.aws_caller_identity.current.id}:*"]
       variable = "aws:SourceArn"
     }
   }
@@ -941,7 +941,7 @@ data "aws_iam_policy_document" "waf_log_delivery" {
 
     condition {
       test     = "ArnLike"
-      values   = ["arn:${data.aws_partition.current.partition}:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.id}:*"]
+      values   = ["arn:${data.aws_partition.current.partition}:logs:*:${data.aws_caller_identity.current.id}:*"]
       variable = "aws:SourceArn"
     }
   }


### PR DESCRIPTION
## Description
This PR resolves an issue where the `attach_waf_log_delivery_policy` inadvertently blocked log delivery from global AWS services (like CloudFront standard logging v2).

Because CloudFront operates its control plane and log delivery out of `us-east-1`, attempting to log to a bucket in any other region results in an `Access Denied` error. The bucket policy was strictly enforcing that the `aws:SourceArn` match the bucket's local region via `${data.aws_region.current.region}`. 

By replacing the region segment of the ARN with a wildcard (`*`), this PR allows cross-region log delivery from global services while securely maintaining the `${data.aws_caller_identity.current.id}` restriction to prevent cross-account spoofing. I updated both the `WafLogDeliveryWrite` and `WafLogDeliveryAclCheck` statements.

## Motivation and Context
Closes #396. Restores functionality for CloudFront standard logging v2 while maintaining defense-in-depth on the delivery principal.

## Breaking Changes
None. This slightly relaxes the region constraint of the policy but maintains strict account-level boundaries.

## How Has This Been Tested?
- [x] Verified `terraform validate` passes cleanly.
- [x] Executed a full `terraform plan`, `apply`, and `destroy` cycle against a live AWS environment using `examples/complete`. Confirmed the AWS API successfully parses and accepts the wildcarded `aws:SourceArn` within the generated bucket policy.