### PR TITLE
fix: Correctly guard analytics/inventory destination policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -14,7 +14,7 @@ locals {
 
   create_bucket_acl = (var.acl != null && var.acl != "null") || length(local.grants) > 0
 
-  attach_policy = var.attach_require_latest_tls_policy || var.attach_access_log_delivery_policy || var.attach_elb_log_delivery_policy || var.attach_lb_log_delivery_policy || var.attach_cloudtrail_log_delivery_policy || var.attach_deny_insecure_transport_policy || var.attach_inventory_destination_policy || var.attach_deny_incorrect_encryption_headers || var.attach_deny_incorrect_kms_key_sse || var.attach_deny_unencrypted_object_uploads || var.attach_deny_ssec_encrypted_object_uploads || var.attach_policy || var.attach_waf_log_delivery_policy
+  attach_policy = var.attach_require_latest_tls_policy || var.attach_access_log_delivery_policy || var.attach_elb_log_delivery_policy || var.attach_lb_log_delivery_policy || var.attach_cloudtrail_log_delivery_policy || var.attach_deny_insecure_transport_policy || var.attach_inventory_destination_policy || var.attach_analytics_destination_policy || var.attach_deny_incorrect_encryption_headers || var.attach_deny_incorrect_kms_key_sse || var.attach_deny_unencrypted_object_uploads || var.attach_deny_ssec_encrypted_object_uploads || var.attach_policy || var.attach_waf_log_delivery_policy
 
   # Placeholders in the policy document to be replaced with the actual values
   policy_placeholders = {
@@ -1300,7 +1300,7 @@ resource "aws_s3_bucket_inventory" "this" {
 # Inventory and analytics destination bucket requires a bucket policy to allow source to PutObjects
 # https://docs.aws.amazon.com/AmazonS3/latest/userguide/example-bucket-policies.html#example-bucket-policies-use-case-9
 data "aws_iam_policy_document" "inventory_and_analytics_destination_policy" {
-  count = local.create_bucket && !var.is_directory_bucket && var.attach_inventory_destination_policy || var.attach_analytics_destination_policy ? 1 : 0
+  count = local.create_bucket && !var.is_directory_bucket && (var.attach_inventory_destination_policy || var.attach_analytics_destination_policy) ? 1 : 0
 
   statement {
     sid    = "destinationInventoryAndAnalyticsPolicy"


### PR DESCRIPTION
## Description

Fixes an operator-precedence bug in the guard for the inventory/analytics destination policy, plus a related wiring gap.

### 1. Precedence bug (index-out-of-range crash)

`data.aws_iam_policy_document.inventory_and_analytics_destination_policy` used:

```hcl
count = local.create_bucket && !var.is_directory_bucket && var.attach_inventory_destination_policy || var.attach_analytics_destination_policy ? 1 : 0
```

In HCL `&&` binds tighter than `||`, so this parsed as
`(create_bucket && !is_directory_bucket && inventory) || analytics`. Setting **`attach_analytics_destination_policy = true`** therefore forces the data source to be evaluated **regardless of `create_bucket`/`is_directory_bucket`**. Its body references `aws_s3_bucket.this[0].arn`, which has `count = 0` for a directory bucket or when `create_bucket = false`, producing:

```
Error: Invalid index ... aws_s3_bucket.this is empty tuple
```

Wrapping the OR restores the intended semantics (the guards apply to both inventory and analytics), matching the already-correct sibling expression at the combined-policy document.

### 2. `local.attach_policy` omitted analytics

`local.attach_policy` listed `attach_inventory_destination_policy` but not `attach_analytics_destination_policy`. So an **analytics-only** configuration (without also setting `attach_policy = true`) computed `attach_policy = false`, and the generated bucket policy — which *does* include the analytics statement — was silently never attached. Added the missing term for symmetry.

## Reproduction

Either combo triggered the crash before this change:
- `is_directory_bucket = true` + `attach_analytics_destination_policy = true`
- `create_bucket = false` + `attach_analytics_destination_policy = true`

The `examples/s3-analytics` happy path (non-directory bucket, `attach_policy = true`) stays green either way, which is why it didn't surface earlier.

## Motivation and Context

I hit this in a stack that composes this module with `attach_analytics_destination_policy`. The fix is a two-token change (parentheses + one missing `||` term); no variables or outputs change, so no docs regeneration is needed.

## How Has This Been Tested?

- [x] `terraform fmt` (clean) and `terraform validate` on `examples/s3-analytics` pass.
- [x] Reviewed the parsed precedence against the sibling expression that already parenthesizes the same OR.

<sub>Developed with AI assistance (Claude Code); I directed the change and verified fmt/validate locally.</sub>
