### PR TITLE
fix: Replace deprecated data.aws_region.current.name with .region in example

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -143,7 +143,7 @@ module "simple_bucket" {
 module "simple_account_regional_bucket" {
   source = "../../"
 
-  bucket           = format("simple-%s-%s-an", data.aws_caller_identity.current.account_id, data.aws_region.current.name)
+  bucket           = format("simple-%s-%s-an", data.aws_caller_identity.current.account_id, data.aws_region.current.region)
   bucket_namespace = "account-regional"
 
   force_destroy = true


### PR DESCRIPTION
## Description
This PR addresses the deprecation warnings reported in #400. While the root module's `main.tf` was successfully updated to use `data.aws_region.current.region` in previous major releases, the `examples/complete/main.tf` file still contained a lingering reference to `data.aws_region.current.name`. This PR updates the example code to use the modern attribute.

## Motivation and Context
Closes #400. Eliminates the `Warning: The attribute "name" is deprecated.` message during `terraform plan` for users testing the complete example with AWS provider versions `>= 6.0.0`.

## Breaking Changes
None. This is a simple attribute update within the example directory and does not affect the core module's backward compatibility.

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [x] I have executed `pre-commit run -a` on my pull request

**Testing Details:**
Navigated to `examples/complete` and successfully ran `terraform init`, `terraform validate`, and `terraform plan`. Verified that the plan output is clean and the `.name` deprecation warning is completely gone.