### PR TITLE
feat(#405): Remove legacy ELB access log delivery policy from main.tf

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,6 @@ No modules.
 | [aws_iam_policy_document.require_latest_tls](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.waf_log_delivery](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
-| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,3 @@
-data "aws_region" "current" {
-  region = var.region
-}
 
 data "aws_canonical_user_id" "this" {
   count = local.create_bucket && local.create_bucket_acl && try(var.owner["id"], null) == null ? 1 : 0
@@ -638,67 +635,10 @@ data "aws_iam_policy_document" "combined" {
   ])
 }
 
-# AWS Load Balancer access log delivery policy
-locals {
-  # List of AWS regions where permissions should be granted to the specified Elastic Load Balancing account ID ( https://docs.aws.amazon.com/elasticloadbalancing/latest/application/enable-access-logging.html#attach-bucket-policy )
-  elb_service_accounts = {
-    us-east-1      = "127311923021"
-    us-east-2      = "033677994240"
-    us-west-1      = "027434742980"
-    us-west-2      = "797873946194"
-    af-south-1     = "098369216593"
-    ap-east-1      = "754344448648"
-    ap-south-1     = "718504428378"
-    ap-northeast-1 = "582318560864"
-    ap-northeast-2 = "600734575887"
-    ap-northeast-3 = "383597477331"
-    ap-southeast-1 = "114774131450"
-    ap-southeast-2 = "783225319266"
-    ap-southeast-3 = "589379963580"
-    ca-central-1   = "985666609251"
-    eu-central-1   = "054676820928"
-    eu-west-1      = "156460612806"
-    eu-west-2      = "652711504416"
-    eu-west-3      = "009996457667"
-    eu-south-1     = "635631232127"
-    eu-north-1     = "897822967062"
-    me-south-1     = "076674570225"
-    sa-east-1      = "507241528517"
-    us-gov-west-1  = "048591011584"
-    us-gov-east-1  = "190560391635"
-    cn-north-1     = "638102146993"
-    cn-northwest-1 = "037604701340"
-  }
-}
-
 data "aws_iam_policy_document" "elb_log_delivery" {
   count = local.create_bucket && var.attach_elb_log_delivery_policy && !var.is_directory_bucket ? 1 : 0
 
-  # Policy for AWS Regions created before August 2022 (e.g. US East (N. Virginia), Asia Pacific (Singapore), Asia Pacific (Sydney), Asia Pacific (Tokyo), Europe (Ireland))
-  dynamic "statement" {
-    for_each = { for k, v in local.elb_service_accounts : k => v if k == data.aws_region.current.region }
-
-    content {
-      sid = format("ELBRegion%s", title(statement.key))
-
-      principals {
-        type        = "AWS"
-        identifiers = [format("arn:%s:iam::%s:root", data.aws_partition.current.partition, statement.value)]
-      }
-
-      effect = "Allow"
-
-      actions = [
-        "s3:PutObject",
-      ]
-
-      resources = [
-        "${aws_s3_bucket.this[0].arn}/*",
-      ]
-    }
-  }
-
-  # Policy for AWS Regions created after August 2022 (e.g. Asia Pacific (Hyderabad), Asia Pacific (Melbourne), Europe (Spain), Europe (Zurich), Middle East (UAE))
+  # Recommended AWS policy using the Elastic Load Balancing service principal.
   statement {
     sid = ""
 


### PR DESCRIPTION
## Description

Remove legacy Elastic Load Balancing access log delivery bucket policy statements and rely exclusively on the AWS-recommended service principal `logdelivery.elasticloadbalancing.amazonaws.com`.

The module currently generates both the recommended service principal permissions and legacy account-based permissions. This change removes the legacy policy statements while preserving the existing access logging functionality.

## Motivation and Context

AWS recommends granting access log delivery permissions through the `logdelivery.elasticloadbalancing.amazonaws.com` service principal.

The additional legacy account-based permissions are no longer necessary and can trigger findings in security and compliance scanning tools because they grant access using a deprecated permissions model.

Removing these statements aligns the generated bucket policy with current AWS recommendations and the principle of least privilege.

Fixes #405

## Breaking Changes

No.

This change does not alter the module interface or require any configuration changes from users.

AWS Elastic Load Balancing access log delivery continues to function as before using the AWS-recommended service principal `logdelivery.elasticloadbalancing.amazonaws.com`.

The change only removes legacy account-based policy statements that are retained by AWS for backward compatibility and are no longer required when using the recommended service principal model.

## How Has This Been Tested?

- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
  - Verified that the generated bucket policy only contains the `logdelivery.elasticloadbalancing.amazonaws.com` service principal permissions
  - Verified that Terraform plans are generated successfully
  - Verified that legacy ELB account-based policy statements are no longer present
  - Verified that Application Load Balancer access logs continue to be successfully delivered to the S3 bucket

- [x] I have executed `pre-commit run -a` on my pull request